### PR TITLE
Fix discrepancy between frequency and interval

### DIFF
--- a/frontend/src/containers/PublicGroup.js
+++ b/frontend/src/containers/PublicGroup.js
@@ -4,8 +4,7 @@ import { connect } from 'react-redux';
 import take from 'lodash/array/take';
 import uniq from 'lodash/array/uniq';
 import values from 'lodash/object/values';
-import sortBy from 'lodash/collection/sortBy'
-import contains from 'lodash/collection/contains';
+import sortBy from 'lodash/collection/sortBy';
 
 import filterCollection from '../lib/filter_collection';
 import formatCurrency from '../lib/format_currency';
@@ -237,8 +236,10 @@ export function donateToGroup(amount, frequency, currency, token) {
     currency
   };
 
- if (contains(['month', 'year'], frequency)) {
-    payment.interval = frequency;
+  if (frequency === 'monthly') {
+    payment.interval = 'month';
+  } else if (frequency === 'yearly') {
+    payment.interval = 'year';
   }
 
   return donate(group.id, payment)

--- a/test/unit/containers/PublicGroup.js
+++ b/test/unit/containers/PublicGroup.js
@@ -58,7 +58,7 @@ describe('PublicGroup container', () => {
       fetchTransactions: noop
     };
 
-    donateToGroup.call({props, setState}, 10, 'month', 'MXN', token)
+    donateToGroup.call({props, setState}, 10, 'monthly', 'MXN', token)
     .then(() => {
       expect(donate).to.have.been.called();
       expect(setState).to.have.been.called();
@@ -101,10 +101,10 @@ describe('PublicGroup container', () => {
       fetchUsers: noop,
       currency: 'MXN',
       fetchTransactions: noop,
-      frequency: 'month'
+      frequency: 'monthly'
     };
 
-    donateToGroup.call({props, setState}, 10, 'month', 'MXN', token)
+    donateToGroup.call({props, setState}, 10, 'monthly', 'MXN', token)
     .then(() => {
       expect(donate).to.have.been.called();
       expect(notify).to.not.have.been.called();
@@ -173,7 +173,7 @@ describe('PublicGroup container', () => {
       email: 'test@gmail.com'
     };
 
-    donateToGroup.call({props}, 10, 'month', 'MXN', token)
+    donateToGroup.call({props}, 10, 'monthly', 'MXN', token)
     .then(() => {
       expect(donate).to.have.been.called();
       expect(notify).to.have.been.called();


### PR DESCRIPTION
NB: a better fix could be to discard the `frequency` concept altogether and use `interval` everywhere.
