### PR TITLE
enable google analytics on all routes in production and staging

### DIFF
--- a/server/middlewares.js
+++ b/server/middlewares.js
@@ -95,7 +95,7 @@ const ga = (req, res, next) => {
     httpOnly: true,
     secret: 'b4;jP(cUqPaf8TuG@U',
     cookie: {
-      secure: (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging'),
+      secure: process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging',
       maxAge: 60*60*24*30*1000 // 1 month
     }
   });

--- a/server/routes.js
+++ b/server/routes.js
@@ -65,11 +65,11 @@ module.exports = (app) => {
    * When we refactor PublicGroup to fetch the group in the container, we can remove
    * the explicit routes and just do `app.use(render)`
    */
-  app.get('/leaderboard', mw.fetchLeaderboard, mw.addTitle('Open Collective Leaderboard'), render);
-  app.get('/subscriptions/:token', mw.fetchSubscriptionsByUserWithToken, mw.addTitle('My Subscriptions'), render);
-  app.get('/subscriptions', mw.fetchSubscriptionsByUserWithToken, mw.addTitle('My Subscriptions'), render);
-  app.get('/:slug([A-Za-z0-9-]+)', mw.fetchGroupBySlug, mw.addMeta, render);
-  app.get('/:slug([A-Za-z0-9-]+)/:type', mw.fetchGroupBySlug, mw.addMeta, render);
-  app.get('/:slug([A-Za-z0-9-]+)/donate/:amount', mw.fetchGroupBySlug, mw.addMeta, render);
-  app.get('/:slug([A-Za-z0-9-]+)/donate/:amount/:interval', mw.fetchGroupBySlug, mw.addMeta, render);
+  app.get('/leaderboard', mw.ga, mw.fetchLeaderboard, mw.addTitle('Open Collective Leaderboard'), render);
+  app.get('/subscriptions/:token', mw.ga, mw.fetchSubscriptionsByUserWithToken, mw.addTitle('My Subscriptions'), render);
+  app.get('/subscriptions', mw.ga, mw.fetchSubscriptionsByUserWithToken, mw.addTitle('My Subscriptions'), render);
+  app.get('/:slug([A-Za-z0-9-]+)', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
+  app.get('/:slug([A-Za-z0-9-]+)/:type', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
+  app.get('/:slug([A-Za-z0-9-]+)/donate/:amount', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
+  app.get('/:slug([A-Za-z0-9-]+)/donate/:amount/:interval', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
 };


### PR DESCRIPTION
I don't understand why this works without a `next()` call at the end, like all other middleware functions.
