### PR TITLE
use WEBSITE_PORT var for custom port when starting server; closes #230

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "NODE_CONFIG_DIR=./server/config node server",
-    "dev": "npm run build && PORT=3000 nf start -j Procfile_dev",
+    "dev": "npm run build && WEBSITE_PORT=3000 nf start -j Procfile_dev",
     "hint": "eslint '**/*.js' --quiet",
     "pretest": "npm run hint",
     "test": "npm run test:server && npm run test:unit",

--- a/server/app.js
+++ b/server/app.js
@@ -91,7 +91,7 @@ app.use((err, req, res, next) => {
  * Port config
  */
 
-app.set('port', process.env.PORT || 3000);
+app.set('port', process.env.WEBSITE_PORT || 3000);
 
 /**
  * Start server

--- a/server/app.js
+++ b/server/app.js
@@ -91,7 +91,7 @@ app.use((err, req, res, next) => {
  * Port config
  */
 
-app.set('port', process.env.WEBSITE_PORT || 3000);
+app.set('port', process.env.WEBSITE_PORT || process.env.PORT || 3000);
 
 /**
  * Start server


### PR DESCRIPTION
**UPDATE**: Heroku needs `PORT`, so we'll use `WEBSITE_PORT` if present, otherwise `PORT`, otherwise the hardcoded default.