### PR TITLE
Added middleware to catch uncaught errors

### DIFF
--- a/server/middlewares.js
+++ b/server/middlewares.js
@@ -139,14 +139,10 @@ const addTitle = (title) => {
 }
 
 const handleUncaughtError = (error, req, res, next) => {
-    if (error.name === 'FetchError')
-    {
-      if (error.code === 'ECONNREFUSED')
-      {
+    if (error.name === 'FetchError') {
+      if (error.code === 'ECONNREFUSED') {
         console.error('API Server is down')
-      }
-      else
-      {
+      } else {
         console.error('There was an error fetching from api')
       }
       console.log('Error', error);
@@ -162,9 +158,7 @@ const handleUncaughtError = (error, req, res, next) => {
           showGA: config.GoogleAnalytics.active
         }
       }); 
-    }
-    else
-    {
+    } else {
       next(error)
     }
 };

--- a/server/middlewares.js
+++ b/server/middlewares.js
@@ -149,9 +149,24 @@ const handleUncaughtError = (error, req, res, next) => {
       {
         console.error('There was an error fetching from api')
       }
+      console.log('Error', error);
+      console.log('Error stack', error.stack);
+      
+      res
+      .status(500)
+      .render('pages/error', {
+        layout: false,
+        message: process.env.NODE_ENV === 'production' ? 'We couldn\'t find that page :(' : `Error ${error.code}: ${error.message}`,
+        stack: process.env.NODE_ENV === 'production' ? '' : error.stack,
+        options: {
+          showGA: config.GoogleAnalytics.active
+        }
+      }); 
     }
-    console.log(error)
-    next()
+    else
+    {
+      next(error)
+    }
 };
 
 export default {

--- a/server/middlewares.js
+++ b/server/middlewares.js
@@ -137,6 +137,23 @@ const addTitle = (title) => {
     next();
   }
 }
+
+const handleUncaughtError = (error, req, res, next) => {
+    if (error.name === 'FetchError')
+    {
+      if (error.code === 'ECONNREFUSED')
+      {
+        console.error('API Server is down')
+      }
+      else
+      {
+        console.error('There was an error fetching from api')
+      }
+    }
+    console.log(error)
+    next()
+};
+
 export default {
   addMeta,
   addTitle,
@@ -145,5 +162,6 @@ export default {
   fetchSubscriptionsByUserWithToken,
   fetchUsers,
   fetchLeaderboard,
-  ga
+  ga,
+  handleUncaughtError
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -82,4 +82,6 @@ module.exports = (app) => {
   app.get('/:slug([A-Za-z0-9-]+)/donate/:amount', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-]+)/donate/:amount/:interval', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-]+)/connect/:service(github)', mw.ga, render);
+
+  app.use(mw.handleUncaughtError)
 };


### PR DESCRIPTION
Determines if the error thrown because the api server is down
Also determines if api server is up, but fetching failed
Any other error is logged