### PR TITLE
Fix badges after repo name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# OpenCollective Website 
+# OpenCollective Website
 
-[![Circle CI](https://circleci.com/gh/OpenCollective/website/tree/master.svg?style=shield&circle-token=529943730e6598363053a54a31969aa0278f0f33)](https://circleci.com/gh/OpenCollective/website/tree/master)
+[![Circle CI](https://circleci.com/gh/OpenCollective/opencollective-website/tree/master.svg?style=shield&circle-token=529943730e6598363053a54a31969aa0278f0f33)](https://circleci.com/gh/OpenCollective/opencollective-website/tree/master)
 [![Slack Status](https://slack.opencollective.com/badge.svg)](https://slack.opencollective.com)
 [![Gitter chat](https://badges.gitter.im/OpenCollective/OpenCollective.svg)](https://gitter.im/OpenCollective/OpenCollective)
-[![Dependency Status](https://david-dm.org/opencollective/website.svg)](https://david-dm.org/opencollective/website)
-[![Known Vulnerabilities](https://snyk.io/test/github/opencollective/website/badge.svg)](https://snyk.io/test/github/opencollective/website)
+[![Dependency Status](https://david-dm.org/opencollective/opencollective-website.svg)](https://david-dm.org/opencollective/opencollective-website)
 
 Note: Currently, this is only serving the `/:slug` and `/:slug/widget` pages.
 The static pages `/`, `/faq`, `/about` are served from the [website-static](https://github.com/opencollective/website-static) server. Eventually we move over those static pages to this repo.

--- a/test/e2e/connect_account_page.js
+++ b/test/e2e/connect_account_page.js
@@ -29,7 +29,7 @@ module.exports = {
       // .assert.urlContains(`https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${callbackUrl}&response_type=code&scope=${githubScope}`)
       // .click('button[name=authorize]') // click 'Authorize application'
 
-      .waitForElementVisible('body', 2000)
+      .waitForElementVisible('body', 4000)
       .assert.urlContains('http://localhost:3000/testcollective')
       .end();
    }


### PR DESCRIPTION
Result: https://github.com/OpenCollective/opencollective-website/tree/badges