### PR TITLE
Fix set max repo fetch 100

### DIFF
--- a/frontend/src/actions/github/fetch_repos.js
+++ b/frontend/src/actions/github/fetch_repos.js
@@ -10,7 +10,7 @@ export default (username) => {
   return dispatch => {
     dispatch(request(username));
 
-    return getThirdParty(`https://api.github.com/users/${username}/repos?per_page=100`, {params: {type: 'owner'}})
+    return getThirdParty(`https://api.github.com/users/${username}/repos?per_page=100&sort=stars`, {params: {type: 'owner'}})
     .then(json => {
       json = json.filter((repo) => repo.stargazers_count >= constants.MIN_STARS_FOR_ONBOARDING);
       dispatch(success(username, json));

--- a/frontend/src/actions/github/fetch_repos.js
+++ b/frontend/src/actions/github/fetch_repos.js
@@ -10,7 +10,7 @@ export default (username) => {
   return dispatch => {
     dispatch(request(username));
 
-    return getThirdParty(`https://api.github.com/users/${username}/repos`, {params: {type: 'owner'}})
+    return getThirdParty(`https://api.github.com/users/${username}/repos?per_page=100`, {params: {type: 'owner'}})
     .then(json => {
       json = json.filter((repo) => repo.stargazers_count >= constants.MIN_STARS_FOR_ONBOARDING);
       dispatch(success(username, json));


### PR DESCRIPTION
Temporary fix, should cover most cases, 100 repositories are shown ordered from highest star count to least.

For completeness, some form of pagination should be implemented.

For https://github.com/OpenCollective/OpenCollective/issues/81#issuecomment-221390767