### PR TITLE
Added banner under PublicGroupWhoWeAre component in PublicGroup

### DIFF
--- a/frontend/src/containers/PublicGroup.js
+++ b/frontend/src/containers/PublicGroup.js
@@ -104,7 +104,15 @@ export class PublicGroup extends Component {
 
         <PublicGroupHero group={group} {...this.props} />
         <PublicGroupWhoWeAre group={group} {...this.props} />
-        <PublicGroupWhyJoin group={group} expenses={expenses} {...this.props} />
+        {group.slug === 'opensource' && 
+          <div className="PublicGroupOpenSourceCTA">
+            <div className="arrow-down"></div>
+            <div className="line1">Apply to create an open collective for your open source project.</div>
+            <div className="line2">We are slowly accepting new open collectives. Reserve your spot today.</div>
+            <a href="/github/apply"><div className="button">APPLY NOW</div></a>
+          </div>
+        }
+        {group.slug !== 'opensource' && <PublicGroupWhyJoin group={group} expenses={expenses} {...this.props} />}
 
         <div className='bg-light-gray px2'>
           <PublicGroupJoinUs {...this.props} donateToGroup={donateToGroup.bind(this)} {...this.props} />

--- a/frontend/src/css/containers/PublicGroup.css
+++ b/frontend/src/css/containers/PublicGroup.css
@@ -145,7 +145,56 @@
   font-size: 1rem;
 }
 
-
+/* Call to action for /opensource */
+.PublicGroupOpenSourceCTA {
+  font-family: "Montserrat-Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  position: relative;
+  letter-spacing: .5px;
+  width: 100%;
+  background-color: black;
+  background-image: url(/static/images/whyjoin-placeholder.png);
+  color: white;
+  padding: 54px 20px 40px 20px;
+  text-align: center;
+  .arrow-down {
+    position: absolute; 
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 0px;
+    height: 0px;
+    border-left: 20px solid transparent;
+    border-right: 20px solid transparent;
+    border-top: 20px solid #F7F7F7;
+    margin: auto;
+  }
+  .line1 {
+    font-size: 20px;
+    font-weight: bold;
+  }
+  .line2 {
+    font-size: 15px;
+    margin-top: 10px;
+    margin-bottom: 20px;
+  }
+  .button {
+    margin: 0 auto;
+    width: 100%;
+    max-width: 270px;
+    border-radius: 50px;
+    background-color: #75cc1f;
+    color: white;
+    text-align: center;
+    font-weight: bold;
+    padding: 14px 24px;
+  }
+  .button:hover {
+    opacity: .96;
+  }
+  a {
+    text-decoration: none;
+  }
+}
 
 /* WHY JOIN */
 .PublicGroup-image-placeholder {


### PR DESCRIPTION
For https://github.com/OpenCollective/OpenCollective/issues/129

Banner only displays when `group.slug` is `opensource`, when true the whyjoin section is hidden as well.

