### PR TITLE
Contributors are listed when group.data.githubUsers is an object:

### DIFF
--- a/frontend/src/components/UserPhoto.js
+++ b/frontend/src/components/UserPhoto.js
@@ -30,14 +30,14 @@ export default class UserPhoto extends React.Component {
   }
 
   render() {
-    const { className, user, addBadge } = this.props;
+    const { className, user, addBadge, onMouseEnter, onMouseLeave } = this.props;
     const avatar = this.state.avatar;
     const styles = {
       backgroundImage: `url(${avatar})`
     };
 
     return (
-      <div className={`UserPhoto bg-no-repeat bg-center relative ${user.tier} ${className} ${avatar ? 'UserPhoto--loaded' : ''} `}>
+      <div className={`UserPhoto bg-no-repeat bg-center relative ${user.tier} ${className} ${avatar ? 'UserPhoto--loaded' : ''} `} onMouseEnter={ onMouseEnter } onMouseLeave={ onMouseLeave }>
         <div className='width-100 height-100 bg-contain bg-no-repeat bg-center' style={styles}></div>
         {addBadge ? (
           <div className='UserPhoto-badge absolute bg-white'>

--- a/frontend/src/components/public_group/ContributorList.js
+++ b/frontend/src/components/public_group/ContributorList.js
@@ -1,0 +1,121 @@
+import React from 'react';
+
+import UserPhoto from '../UserPhoto';
+
+const MAX_ITEMS_PER_PAGE = 16;
+
+export default class ContributorList extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      pageIndex: 0,
+      showHoverCard: false,
+      hoverCardTarget: null
+    };
+  }
+
+ render() { 
+  const { contributors } = this.props;
+  const contributorsCopy = contributors.slice();
+  const { pageIndex, showHoverCard, hoverCardTarget } = this.state;
+  const prevIsPossible = this.prevIsPossible();
+  const nextIsPossible = this.nextIsPossible();
+  const pageCount = Math.floor(contributors.length / MAX_ITEMS_PER_PAGE) + 1;
+  const pages = new Array(pageCount);
+  for (var i = 0; i < pageCount; i++) {
+    pages[i] = contributorsCopy.splice(0, MAX_ITEMS_PER_PAGE);
+  }
+
+  return (
+      <div className='ContributorList'>
+        <div className='ContributorList-body'>
+          <div className='ContributorList-left'>
+            <div className={`ImagePicker-prev ${prevIsPossible ? 'active' : ''}`} onClick={prevIsPossible ? this.prev.bind(this) : Function.prototype}></div>
+          </div>
+          <div className='ContributorList-right'>
+            <div className={`ImagePicker-next ${nextIsPossible ? 'active' : ''}`} onClick={nextIsPossible ? this.next.bind(this) : Function.prototype}></div>
+          </div>
+          <div className='ContributorList-container'>
+            {pages[pageIndex].map((contributor, index) => {
+              return (
+                <div key={index} className="ContributorList-item">
+                  {showHoverCard && contributor === hoverCardTarget && (
+                      <div className='ContributorList-HoverCard'>
+                        <div className='HoverCard-name'>{contributor.name}</div>
+                        <div className='HoverCard-role'>{contributor.core ? 'Core Contributor' : 'Contributor'}</div>
+                        <div className='HoverCard-stats'>
+                          <span></span>
+                          <span>{`${contributor.stats.c} commits`}</span>
+                          {typeof contributor.stats.a === 'number' && 
+                            <span>
+                              &nbsp;
+                              <span>/</span>
+                              &nbsp;
+                              <span className='-add'>{`${contributor.stats.a}++`}</span>
+                            </span>
+                          }
+                          {typeof contributor.stats.d === 'number' && 
+                            <span>
+                              &nbsp;
+                              <span>/</span>
+                              &nbsp;
+                              <span className='-del'>{`${contributor.stats.d}--`}</span>
+                            </span>
+                          }
+                        </div>
+                      </div>
+                    )
+                  }
+                  <UserPhoto 
+                    key={contributor.avatar}
+                    user={{avatar: contributor.avatar}}
+                    addBadge={contributor.core} 
+                    onMouseEnter={() => { this.setHoverCard(contributor) }}
+                    onMouseLeave={() => { this.setHoverCard() }}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </div>
+        <div className='ContributorList-pagination'>
+          <ul className='ImagePicker-dot-list'>
+            {pages.map(
+              (option, index) => {
+                return <li key={index} onClick={() => this.setState({pageIndex: index})} className={pageIndex === index ? 'selected' : ''}></li>;
+              }
+            )}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+
+  setHoverCard(target) {
+    if (!target) {
+      this.setState({showHoverCard: false});
+    } else {
+      this.setState({showHoverCard: true, hoverCardTarget: target});
+    }
+  }
+
+  nextIsPossible() {
+    const pageIndexCount = Math.floor(this.props.contributors.length / MAX_ITEMS_PER_PAGE);
+    const { pageIndex } = this.state;
+    return pageIndex < pageIndexCount;
+  }
+
+  prevIsPossible() {
+    const { pageIndex } = this.state;
+    return pageIndex > 0;
+  }
+
+  next() {
+    this.setState({pageIndex: this.state.pageIndex + 1});
+  }
+
+  prev() {
+    this.setState({pageIndex: this.state.pageIndex - 1});
+  }
+}

--- a/frontend/src/containers/PublicGroup.js
+++ b/frontend/src/containers/PublicGroup.js
@@ -20,6 +20,7 @@ import PublicGroupExpenses from '../components/public_group/PublicGroupExpenses'
 import PublicGroupDonations from '../components/public_group/PublicGroupDonations';
 import PublicGroupSignupV2 from '../components/public_group/PublicGroupSignupV2';
 import PublicGroupThanksV2 from '../components/public_group/PublicGroupThanksV2';
+import ContributorList from '../components/public_group/ContributorList';
 
 import fetchGroup from '../actions/groups/fetch_by_id';
 import fetchUsers from '../actions/users/fetch_by_group';
@@ -98,6 +99,21 @@ export class PublicGroup extends Component {
 
     const publicGroupClassName = `PublicGroup ${group.slug}`;
 
+    // `false` if there are no `group.data.githubContributors`, otherwise formats results for `ContributorList`
+    const contributors = (group.data && group.data.githubContributors) && Object.keys(group.data.githubContributors).map((username) => {
+      const commits = group.data.githubContributors[username];
+      return {
+        core: false,
+        name: username,
+        avatar: `https://avatars.githubusercontent.com/${username}?s=64`,
+        stats: {
+          c: commits,
+          a: null, 
+          d: null
+        }
+      }
+    }).sort((A, B) => (B.core * Number.MAX_SAFE_INTEGER + B.stats.c) - (A.core * Number.MAX_SAFE_INTEGER + A.stats.c));
+
     return (
       <div className={publicGroupClassName}>
         <Notification />
@@ -113,6 +129,13 @@ export class PublicGroup extends Component {
           </div>
         }
         {group.slug !== 'opensource' && <PublicGroupWhyJoin group={group} expenses={expenses} {...this.props} />}
+        {contributors && 
+          <div className="PublicGroup-os-contrib-container">
+            <div className="line1" >Contributors</div>
+            <ContributorList contributors={contributors} />
+          </div>
+        }
+        <PublicGroupWhyJoin group={group} expenses={expenses} {...this.props} />
 
         <div className='bg-light-gray px2'>
           <PublicGroupJoinUs {...this.props} donateToGroup={donateToGroup.bind(this)} {...this.props} />

--- a/frontend/src/containers/PublicGroup.js
+++ b/frontend/src/containers/PublicGroup.js
@@ -128,14 +128,13 @@ export class PublicGroup extends Component {
             <a href="/github/apply"><div className="button">APPLY NOW</div></a>
           </div>
         }
-        {group.slug !== 'opensource' && <PublicGroupWhyJoin group={group} expenses={expenses} {...this.props} />}
         {contributors && 
           <div className="PublicGroup-os-contrib-container">
             <div className="line1" >Contributors</div>
             <ContributorList contributors={contributors} />
           </div>
         }
-        <PublicGroupWhyJoin group={group} expenses={expenses} {...this.props} />
+        {group.slug !== 'opensource' && <PublicGroupWhyJoin group={group} expenses={expenses} {...this.props} />}
 
         <div className='bg-light-gray px2'>
           <PublicGroupJoinUs {...this.props} donateToGroup={donateToGroup.bind(this)} {...this.props} />

--- a/frontend/src/css/components/ContributorList.css
+++ b/frontend/src/css/components/ContributorList.css
@@ -1,0 +1,126 @@
+.ContributorList {
+	position: relative;
+	min-height: 140px;
+	width: 100%;
+	max-width: 1000px;
+	margin: 0 auto;
+	box-sizing: border-box;
+	margin-top: 20px;
+}
+
+.ContributorList-left {
+	position: absolute;
+	width: 44px;
+	height: 44px;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	margin: auto;
+}
+
+.ContributorList-right {
+	position: absolute;
+	width: 44px;
+	height: 44px;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	margin: auto;
+}
+
+.ContributorList-body {
+	position: relative;
+	text-align: center;
+	padding-left: 40px;
+	padding-right: 40px;
+	.UserPhoto {
+		display: inline-block;
+		margin: 20px;
+		&:hover {
+			cursor: pointer;
+		}
+	}
+}
+
+.ContributorList-container {
+	position: relative;
+}
+
+.ContributorList-pagination {
+	width: 100%;
+	height: 10px;
+	margin-top: 30px;
+}
+
+.ContributorList-item {
+	position: relative;
+	display: inline-block;
+}
+
+.ContributorList-HoverCard {
+	box-sizing: border-box;
+	position: absolute;
+	z-index: 999;
+	min-width: 210px;
+	height: 113px;
+	border-radius: 5px;
+	background-color: white;
+	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.25);
+	top: -110px;
+	left: -52px;
+	padding-top: 20px;
+	padding-bottom: 25px;
+	padding-left: 10px;
+	padding-right: 10px;
+
+	&:after, &:before {
+		top: 100%;
+		left: 50%;
+		border: solid transparent;
+		content: '';
+		height: 0;
+		width: 0;
+		position: absolute;
+		pointer-events: none;
+	}
+
+	&:after {
+		border-color: rgba(136, 183, 213, 0);
+		border-top-color: #fff;
+		border-width: 4px;
+		margin-left: -4px;
+	}
+	&:before {
+		border-color: rgba(0, 0, 0, 0);
+		border-top-color: rgba(0, 0, 0, 0.15);
+		border-width: 5px;
+		margin-left: -5px;
+	}
+
+}
+
+.HoverCard-name {
+	font-family: Montserrat;
+	font-size: 17px;
+	color: #46b0ed;
+	font-weight: bold;
+}
+
+.HoverCard-role {
+  font-family: Lato;
+  font-size: 14px;
+  color: #919699;
+}
+
+.HoverCard-stats {
+	font-family: Lato;
+	font-size: 12px;
+	color: #bbc1c4;
+	margin-top: 6px;
+	.-add {
+		color: rgb(110, 202, 64);
+	}
+	.-del {
+		color: rgb(195, 49, 7);
+	}
+}

--- a/frontend/src/css/containers/PublicGroup.css
+++ b/frontend/src/css/containers/PublicGroup.css
@@ -399,3 +399,15 @@
     color: #494b4d;
   }
 }
+
+.PublicGroup-os-contrib-container {
+  text-align: center;
+  padding-top: 20px;
+  padding-bottom: 100px;
+  background-color: #F9FAFA;
+  .line1 {
+    font-family: montserratlight;
+    font-size: 22px;
+    color: #4d4d4d;
+  }
+}

--- a/frontend/src/css/main.css
+++ b/frontend/src/css/main.css
@@ -42,6 +42,7 @@
 @import './components/ActivityItem.css';
 @import './components/Button.css';
 @import './components/Checkbox.css';
+@import './components/ContributorList.css';
 @import './components/ContributorPicker.css';
 @import './components/Currency.css';
 @import './components/CustomTextArea.css';


### PR DESCRIPTION
with a username as key and its value the total number of commits.
Modified UserPhoto so it listens to hover events.

For https://github.com/OpenCollective/OpenCollective/issues/122

As long as `group.data.githubUsers` is falsy it will not display. 
Contributors are sorted so core contributors are first followed by number of commits after.
Only commits are displayed, if additions and/or deletions are included they will be displayed as well.

@asood123 @boneskull  
`group.data` does not tell us whether a user is a core contributor or not. How can we determine core contributors?
