### PR TITLE
Set box-sizing to border-box, banner causes h-scroll to show on page

### DIFF
--- a/frontend/src/css/containers/PublicGroup.css
+++ b/frontend/src/css/containers/PublicGroup.css
@@ -147,6 +147,7 @@
 
 /* Call to action for /opensource */
 .PublicGroupOpenSourceCTA {
+  box-sizing: border-box;
   font-family: "Montserrat-Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
   position: relative;
   letter-spacing: .5px;


### PR DESCRIPTION
You can see the bug live now: https://opencollective.com/opensource

The banner's width causes the Horizontal scroller show, this fixes it

@asood123  please merge this fix, its a css one-liner