### PR TITLE
implement avatarHeight option for /:slug/:tier/:position/avatar

### DIFF
--- a/server/controllers/banner.js
+++ b/server/controllers/banner.js
@@ -53,10 +53,16 @@ module.exports = {
     const user = (position < users.length) ?  users[position] : {};
     const format = req.params.format || 'svg';
 
-    var maxHeight = (format === 'svg' ) ? 128 : 64;
-    if(tier.match(/silver/)) maxHeight *= 1.25;
-    if(tier.match(/gold/)) maxHeight *= 1.5;
-    if(tier.match(/diamond/)) maxHeight *= 2;
+    var maxHeight;
+
+    if(req.query.avatarHeight) {
+      maxHeight = Number(req.query.avatarHeight);
+    } else {
+      maxHeight = (format === 'svg' ) ? 128 : 64;
+      if(tier.match(/silver/)) maxHeight *= 1.25;
+      if(tier.match(/gold/)) maxHeight *= 1.5;
+      if(tier.match(/diamond/)) maxHeight *= 2;
+    }
 
     // We only record a page view when loading the first avatar
     if(position==0) {

--- a/test/server/banner.spec.js
+++ b/test/server/banner.spec.js
@@ -37,7 +37,6 @@ describe("avatar", () => {
       .get('/yeoman/sponsor/0/avatar.svg')
       .expect('content-type', 'image/svg+xml; charset=utf-8')
       .expect((res) => {
-        console.log("dimensions: ", sizeOf(res.body));
         res.body = sizeOf(res.body);
       })
       .expect(200, { width: 387, height: 64, type: 'svg' }, done);
@@ -69,6 +68,15 @@ describe("avatar", () => {
       .get(`/yeoman/backers/${(mocks.backers.length+1)}/avatar`)
       .expect('Location', '/static/images/1px.png')
       .expect(302, done);
+  });
+
+  it("handles the avatarHeight option", (done) => {
+    request(app)
+      .get('/yeoman/backers/0/avatar.jpg?avatarHeight=256')
+      .expect((res) => {
+        res.body = sizeOf(res.body);
+      })
+      .expect(200, { width: 260, height: 260, type: 'jpg' }, done);
   });
 });
 


### PR DESCRIPTION
*Please note that I could not actually test this (except for the unit test) since I wasn't sure how to add mock data locally.*

This adds the `avatarHeight` option for avatar images, which I need for the react-boilerplate README to make the bronze sponsors slightly bigger than the backers.

This is a shot in the dark, let me know if you want a different solution!