### PR TITLE
Added LoginTopBar component

### DIFF
--- a/frontend/src/assets/images/oc-logo-icon.svg
+++ b/frontend/src/assets/images/oc-logo-icon.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="39px" height="39px" viewBox="0 0 39 39" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 3.8.3 (29802) - http://www.bohemiancoding.com/sketch -->
+    <title>F41BE6DF-90FC-40C4-B22A-F0CAFA582A6D</title>
+    <desc>Created with sketchtool.</desc>
+    <defs></defs>
+    <g id="home" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="HOME" transform="translate(-20.000000, -15.000000)">
+            <g id="::-loged-in" transform="translate(0.000000, 5.000000)">
+                <g id="icon" transform="translate(20.000000, 10.000000)">
+                    <g id="::-icon">
+                        <path d="M31.6,19.9 C31.6,22.3 30.9,24.6 29.7,26.5 L34.6,31.4 C37,28.2 38.5,24.2 38.5,19.9 C38.5,15.6 37,11.6 34.6,8.4 L29.7,13.3 C30.9,15.2 31.6,17.4 31.6,19.9 L31.6,19.9 Z" id="Shape" fill="#B8D3F4"></path>
+                        <path d="M19.4,32.1 C12.7,32.1 7.2,26.6 7.2,19.9 C7.2,13.2 12.7,7.7 19.4,7.7 C21.9,7.7 24.1,8.4 26,9.7 L30.9,4.8 C27.7,2.4 23.7,0.9 19.4,0.9 C8.9,0.9 0.3,9.4 0.3,20 C0.3,30.6 8.9,39 19.4,39 C23.8,39 27.8,37.5 31,35.1 L26.1,30.2 C24.2,31.4 21.9,32.1 19.4,32.1 L19.4,32.1 Z" id="Shape" fill="#46B0ED"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/frontend/src/components/LoginTopBar.js
+++ b/frontend/src/components/LoginTopBar.js
@@ -1,0 +1,100 @@
+import React, { Component, PropTypes } from 'react';
+
+export default class OnBoardingHeader extends Component {
+
+  static propTypes = {
+    user: PropTypes.shape({
+      name: PropTypes.string,
+      avatar: PropTypes.string
+    })
+  }
+
+  static defaultProps = {
+    user: null
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoggedIn: Boolean(props.user),
+      showProfileMenu: false
+    };
+  }
+
+  renderProfileMenu() {
+    return (
+      <div className='LoginTopBarProfileMenu' onClick={(e) => e.nativeEvent.stopImmediatePropagation()}>
+        <div>
+          <div className='LoginTopBarProfileMenuHeading'>
+            <span>collectives</span>
+            <div className='-dash'></div>
+          </div>
+          <ul>
+            <li><a href='#'>Subscriptions</a></li>
+            <li><a href='#'>Contributors</a></li>
+          </ul>
+        </div>
+        <div>
+          <div className='LoginTopBarProfileMenuHeading'>
+            <span>my account</span>
+            <div className='-dash'></div>
+          </div>
+          <ul>
+            <li><a href='#'>Profile</a></li>
+            <li><a className='-blue' href='/logout'>Log Out</a></li>
+          </ul>
+        </div>
+      </div>
+    )
+  }
+
+  render() {
+    const { user } = this.props;
+    const { isLoggedIn, showProfileMenu } = this.state;
+    const avatar = isLoggedIn ? user.avatar : null;
+    const name = isLoggedIn ? user.name : null;
+    return (
+      <div className='LoginTopBar'>
+        <a href="/">
+          <div className='LoginTopBar-logo'></div>
+        </a>
+        <div className='LoginTopBar-nav'>
+          <a className='LoginTopBarButton' href='#'>start a collective</a>
+          <a className='LoginTopBarLink' href='/how'>How it works</a>
+          <a className='LoginTopBarLink' href='/discover'>Discover</a>
+          <div className='LoginTopBarSeperator'></div>
+          {isLoggedIn && 
+            <div className={`LoginTopBarProfileButton ${showProfileMenu ? '-active' : ''}`} onClick={this.toggleProfileMenu.bind(this)}>
+              {avatar && <div className='LoginTopBarProfileButton-avatar' style={{backgroundImage: `url(${avatar})`}}></div>}
+              {name && <div className='LoginTopBarProfileButton-name'>{name}</div>}
+              <div className='LoginTopBarProfileButton-caret'></div>
+              {showProfileMenu && this.renderProfileMenu()}
+            </div>
+          }
+          {!isLoggedIn && <a className='LoginTopBarLink' href='/login'>Login</a>}
+          {!isLoggedIn && <a className='LoginTopBarLink -blue' href='/register'>Sign up</a>}
+        </div>
+      </div>
+    )
+  }
+
+  componentDidMount() {
+    this.onClickOutsideRef = this.onClickOutside.bind(this);
+    document.addEventListener('click', this.onClickOutsideRef);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.onClickOutsideRef);
+  }
+
+  onClickOutside() {
+    this.setState({showProfileMenu: false});
+  }
+
+  toggleProfileMenu(e) {
+    if (e.target.className.indexOf('LoginTopBarProfileButton') !== -1) {
+      this.setState({showProfileMenu: !this.state.showProfileMenu});
+      e.nativeEvent.stopImmediatePropagation();
+    }
+  }
+}

--- a/frontend/src/css/components/LoginTopBar.css
+++ b/frontend/src/css/components/LoginTopBar.css
@@ -1,0 +1,233 @@
+.LoginTopBar {
+  position: relative;
+  height: 70px;
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.2);
+  .LoginTopBar-logo {
+    position: absolute;
+    background-image: url(../images/oc-logo-icon.svg);
+    background-repeat: no-repeat;
+    background-size: contain;
+    width: 40px;
+    height: 40px;
+    left: 20px;
+    top: 15px;
+  }
+  .LoginTopBar-nav {
+    position: absolute;
+    right: 20px;
+    padding-top: 15px;
+    .LoginTopBarProfileButton,
+    .LoginTopBarButton,
+    .LoginTopBarLink {
+      margin: 0 10px;
+    }
+    .LoginTopBarButton {
+      box-sizing: border-box;
+      display: inline-block;
+      height: 30px;
+      border-radius: 100px;
+      border: solid 2px #46b0ed;
+      font-size: 11px;
+      letter-spacing: 1px;
+      text-align: center;
+      color: #46b0ed;
+      text-transform: uppercase;
+      padding: 4px 15px;
+      cursor: pointer;
+      font-weight: bold;
+      &:hover, &:active {
+        background-color: #46b0ed;
+        color: white;
+      }
+    }
+    .LoginTopBarLink {
+      box-sizing: border-box;
+      display: inline-block;
+      font-size: 12px;
+      letter-spacing: 1px;
+      text-align: center;
+      color: #b4bbbf;
+      text-transform: capitalize;
+      padding: 4px 0px;
+      cursor: pointer;
+      &:hover, &:active {
+        color: #363636;
+      }
+      &.-blue {
+        color: #46b0ed;
+        &:hover, &:active {
+          color: #46b0ed;
+        }
+      }
+    }
+    .LoginTopBarSeperator {
+      display: inline-block;
+      width: 1px;
+      margin: 0 5px;
+      height: 30px;
+      height: 40px;
+      background-color: #e6e6e6;
+      vertical-align: middle;
+    }
+    .LoginTopBarProfileButton {
+      position: relative;
+      box-sizing: border-box;
+      display: inline-block;
+      height: 40px;
+      border-radius: 5px;
+      vertical-align: middle;
+      margin-right: 0;
+      padding: 6px 11px;
+      &:hover {
+        background-color: #fbfbfb;
+        cursor: pointer;
+        .LoginTopBarProfileButton-caret {
+          &:after {
+            border-top: 5px solid #fbfbfb;
+          }
+        }
+      }
+      &:active, 
+      &.-active {
+        background-color: #f7f7f7;
+        .LoginTopBarProfileButton-caret {
+          &:after {
+            border-top: 5px solid #f7f7f7;
+          }
+        }
+      }
+      .LoginTopBarProfileButton-avatar {
+        display: inline-block;
+        width: 26px;
+        height: 26px;
+        background-color: #fdfdfd;
+        vertical-align: middle;
+        border-radius: 100%;
+        overflow: hidden;
+        background-size: contain;
+        margin-right: 5px;
+      }
+      .LoginTopBarProfileButton-name {
+        display: inline-block;
+        height: 14px;
+        font-size: 12px;
+        font-weight: bold;
+        color: #46b0ed;
+        margin: 0 5px;
+      }
+      .LoginTopBarProfileButton-caret {
+        position: relative;
+        display: inline-block;
+        width: 14px;
+        height: 6px;
+        &:before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          border-top: 6px solid #46b0ed;
+          border-left: 6px solid transparent;
+          border-right: 6px solid transparent;
+        }
+        &:after {
+          content: '';
+          position: absolute;
+          left: 1px;
+          top: 0;
+          border-top: 5px solid white;
+          border-left: 5px solid transparent;
+          border-right: 5px solid transparent;
+        }
+      }
+    }
+    .LoginTopBarProfileMenu {
+      position: absolute;
+      top: 40px;
+      right: 0;
+      z-index: 999;
+      min-width: 170px;
+      max-width: 300px;
+      border-radius: 5px;
+      background-color: #ffffff;
+      box-shadow: 0 -1px 2px 0 rgba(0, 0, 0, 0.1);
+      border: solid 1px #f2f2f2;
+      padding: 20px 0;
+    }
+  }
+}
+
+.LoginTopBarProfileMenu {
+  ul {
+    width: 100%;
+    list-style-type: none;
+    margin-top: 10px;
+    margin-bottom: 20px;
+    padding: 0;
+    overflow: hidden;
+    li {
+      box-sizing: border-box;
+      float: left;
+      width: 100%;
+      padding: 0 10px;
+      a {
+        box-sizing: border-box;
+        display: inline-block;
+        width: 100%;
+        text-decoration: none;
+        font-family: Montserrat;
+        font-size: 14px;
+        font-weight: normal;
+        text-align: left;
+        color: #84898c;
+        padding: 1px 20px;
+        border-radius: 4px;
+        &:active,
+        &:hover {
+          background-color: #f0f0f0;
+        }
+        &.-blue {
+          color: #46b0ed;
+        }
+      }
+    }
+  }
+  div:last-child ul {
+    margin-bottom: 0;
+  }
+}
+
+.LoginTopBarProfileMenuHeading {
+  position: relative;
+  font-family: Montserrat;
+  font-size: 10px;
+  font-weight: bold;
+  text-align: left;
+  color: #b4bbbf;
+  padding: 0 20px;
+  text-transform: uppercase;
+  cursor: default;
+  height: 13px;
+  span {
+    display: inline-block;
+    position: absolute;
+    height: 13px;
+    background-color: white;
+    z-index: 1;
+    padding-right: 5px;
+  }
+  .-dash {
+    position: absolute;
+    top: 7px;
+    left: 20px; 
+    right: 20px;
+    height: 1px;
+    background-color: #e6e6e6;
+    z-index: 0;
+  }
+}
+
+.LoginTopBar-nav .LoginTopBarLink:last-child {
+  margin-right: 0;
+  padding-right: 0;
+}

--- a/frontend/src/css/main.css
+++ b/frontend/src/css/main.css
@@ -60,6 +60,7 @@
 @import './components/InlineToggle.css';
 @import './components/Input.css';
 @import './components/Label.css';
+@import './components/LoginTopBar.css';
 @import './components/Metric.css';
 @import './components/Notification.css';
 @import './components/ProfilePhoto.css';


### PR DESCRIPTION
For https://github.com/OpenCollective/OpenCollective/issues/154

A single property `user` is accepted, if it is passed, then topbar shows a profile menu with the avatar and name of the user on the right hand side.
The component will collapse the avatar if it is falsy, so only the name shows when missing.

This is simply the component, it has not replaced the current public topbar anywhere.

To use it:

```js
import LoginTopBar from '../components/LoginTopBar';

const user = {
  avatar: 'https://avatars2.githubusercontent.com/u/2263170?v=3&s=26', 
  name: 'Ascari Gutierrez'
};

// When rendering
<LoginTopBar user={user} />
```

# Preview
Using the new HomePage as an example by replacing the `OnBoardingHeader` component with `LoginTopBar`.

![Logged Out](https://my.mixtape.moe/acffzs.png)

![Logged In](https://my.mixtape.moe/cqawqo.png)
