### PR TITLE
Fix links in banner svg

### DIFF
--- a/server/controllers/banner.js
+++ b/server/controllers/banner.js
@@ -192,7 +192,7 @@ module.exports = {
         const rawData = responses[i][1];
 
         const contentType = headers['content-type'];
-        const website = (users[i]) ? users[i].website : `${config.host.website}/${slug}`;
+        const website = (users[i] && users[i].website) ? users[i].website : `${config.host.website}/${slug}`;
         const base64data = new Buffer(rawData).toString('base64');
 
         var avatarWidth = avatarHeight;
@@ -211,10 +211,8 @@ module.exports = {
           posX = margin;
         }
         var image = `<image x="${posX}" y="${posY}" width="${avatarWidth}" height="${avatarHeight}" xlink:href="data:${contentType};base64,${base64data}"/>`;
-        if(website) {
-          image = `<a xlink:href="${website.replace(/&/g,'&amp;')}">${image}</a>`;
-        }
-        images.push(image);
+        var imageLink = `<a xlink:href="${website.replace(/&/g,'&amp;')}" target="_blank">${image}</a>`;
+        images.push(imageLink);
         posX += avatarWidth + margin;
       };
 

--- a/test/server/banner.spec.js
+++ b/test/server/banner.spec.js
@@ -214,4 +214,21 @@ describe("banner", () => {
       })
       .expect(200, done);
   });
+
+  it('has target blank on the links', done => {
+    request(app)
+      .get('/yeoman/backers.svg')
+      .expect('content-type', 'image/svg+xml; charset=utf-8')
+      .expect(res => {
+        const svg = new Buffer(res.body).toString('utf8');
+        const links = svg.match(/<a([^>]+)>/g);
+        res.body = { links };
+      })
+      .expect({
+        links: [
+          '<a xlink:href="https://www.julianmotz.com" target="_blank">'
+        ]
+      })
+      .expect(200, done);
+  });
 })


### PR DESCRIPTION
Links were opening inside the svg object, so adding a target to open them in a new tab fixes the issue.

I also fixed the url, to always have a link for every user (either the user's website or the OC slug url), because I believe it was another issue... Some users didn't have urls (@asood123 for example). Let me know if it was expected and I'll revert this part if needed.