### PR TITLE
Shorten description whitespace (and overall card height) by ~20px.

### DIFF
--- a/frontend/src/css/components/CollectiveCard.css
+++ b/frontend/src/css/components/CollectiveCard.css
@@ -116,7 +116,7 @@
 
 .CollectiveCard:not(.CollectiveCard--large) {
   width: 320px;
-  height: 454px;
+  height: 435px;
   margin: 15px;
   .CollectiveCard-head {
     width: 100%;
@@ -137,6 +137,7 @@
       margin: 0 15px;
       font-size: 14px;
       line-height: 1.24;
+      height: 90px;
     }
   }
   .CollectiveCard-footer {


### PR DESCRIPTION
Fix mentioned here: https://github.com/OpenCollective/opencollective-website/pull/345#issuecomment-233685548

NOTE: These are the maximum characters that will fit in each element:

**.CollectiveCard-name**
Max 27 characters. `text-overflow: ellipsis`

**.CollectiveCard-description**
Max 231 characters. `overflow: hidden`