### PR TITLE
Fix sponsor CollectiveCard

### DIFF
--- a/frontend/src/css/components/CollectiveCard.css
+++ b/frontend/src/css/components/CollectiveCard.css
@@ -92,7 +92,7 @@
     }
   }
   &.sponsor {
-    height: 310px;
+    height: 400px !important;
     .CollectiveCard-head {
       height: 160px;
       .CollectiveCard-background {
@@ -108,7 +108,15 @@
         display: none;
       }
       .CollectiveCard-description {
-        margin-top: 10px;
+        margin-top: 25px !important;
+      }
+    }
+    .CollectiveCard-footer {
+      & > .clearfix > .col {
+        width: 50%;
+        &:nth-child(1) {
+          display: none;
+        }
       }
     }
   }


### PR DESCRIPTION
Assert height at 400px
Hide name
Align description vertically 
Hide first footer metric and center align other 2 footer metrics

**Assumptions**
+ A sponsor card does not display their name i.e `CollectiveCard-name`, as the logo should convey this info.
+ In a sponsor card, there are only two entries in the footer i.e `CollectiveCard-footer`, as oppose to the default 3. The **FIRST**, entry is the one that is hidden.

So far, here are the available styles a `CollectiveCard` can become:

![preview](https://my.mixtape.moe/sczzue.png)