### PR TITLE
When clicking notification, close notification

### DIFF
--- a/frontend/src/containers/Notification.js
+++ b/frontend/src/containers/Notification.js
@@ -21,7 +21,7 @@ class Notification extends Component {
     }
 
     return (
-      <div className={`Notification Notification--${status}`}>
+      <div className={`Notification Notification--${status}`} onClick={() => this.props.resetNotifications()}>
         {this.icon(status)}
         {notification.message}
       </div>


### PR DESCRIPTION
When there is a `Notification` container rendered, there is no way to hide it.

Fix will hide notification, when component is clicked.

![preview](https://my.mixtape.moe/nwgksf.png)