### PR TITLE
token wasn't being passed properly

### DIFF
--- a/frontend/src/actions/subscriptions/cancel.js
+++ b/frontend/src/actions/subscriptions/cancel.js
@@ -5,43 +5,36 @@ import * as constants from '../../constants/subscriptions';
  * Cancel a subscription
  */
 
-export default (id, token) => {
+export default (id) => {
   return dispatch => {
-    dispatch(request(id, token));
-    return post(`/subscriptions/${id}/cancel`, {}, {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    })
-    .then(() => dispatch(success(id, token)))
+    dispatch(request(id));
+    return post(`/subscriptions/${id}/cancel`)
+    .then(() => dispatch(success(id)))
     .catch(error => {
-      dispatch(failure(id, token, error));
+      dispatch(failure(id, error));
       throw new Error(error.message);
     });
   };
 };
 
-function request(id, token) {
+function request(id) {
   return {
     type: constants.CANCEL_SUBSCRIPTION_REQUEST,
-    id,
-    token
+    id
   };
 }
 
-export function success(id, token) {
+export function success(id) {
   return {
     type: constants.CANCEL_SUBSCRIPTION_SUCCESS,
-    id,
-    token
+    id
   };
 }
 
-function failure(id, token, error) {
+function failure(id, error) {
   return {
     type: constants.CANCEL_SUBSCRIPTION_FAILURE,
     id,
-    token,
     error
   };
 }

--- a/frontend/src/actions/subscriptions/get.js
+++ b/frontend/src/actions/subscriptions/get.js
@@ -5,26 +5,24 @@ import * as constants from '../../constants/subscriptions';
  * Fetch subscriptions for a user
  */
 
-export default (token) => {
+export default () => {
   return dispatch => {
-    dispatch(request(token));
+    dispatch(request());
     return get(`/subscriptions`)
-    .then(json => dispatch(success(token, json)))
+    .then(json => dispatch(success(json)))
     .catch(error => dispatch(failure(error)));
   };
 };
 
-function request(token) {
+function request() {
   return {
     type: constants.GET_SUBSCRIPTIONS_REQUEST,
-    token
   };
 }
 
-function success(token, json) {
+function success(json) {
   return {
     type: constants.GET_SUBSCRIPTIONS_SUCCESS,
-    token,
     subscriptions: json
   };
 }
@@ -32,6 +30,6 @@ function success(token, json) {
 function failure(error) {
   return {
     type: constants.GET_SUBSCRIPTIONS_FAILURE,
-    error,
+    error
   };
 }

--- a/test/unit/actions/subscriptions/cancel.js
+++ b/test/unit/actions/subscriptions/cancel.js
@@ -11,7 +11,6 @@ describe('subscriptions/cancel', () => {
   afterEach(() => nock.cleanAll());
 
   it('dispatches CANCEL_SUBSCRIPTION_SUCCESS', (done) => {
-    const token = 'token_abc';
     const id = 1;
 
     nock(env.API_ROOT)
@@ -20,19 +19,18 @@ describe('subscriptions/cancel', () => {
 
     const store = mockStore({});
 
-    store.dispatch(cancelSubscription(id, token))
+    store.dispatch(cancelSubscription(id))
     .then(() => {
       const [request, success] = store.getActions();
 
-      expect(request).toEqual({ type: constants.CANCEL_SUBSCRIPTION_REQUEST, id, token });
-      expect(success).toEqual({ type: constants.CANCEL_SUBSCRIPTION_SUCCESS, id, token });
+      expect(request).toEqual({ type: constants.CANCEL_SUBSCRIPTION_REQUEST, id });
+      expect(success).toEqual({ type: constants.CANCEL_SUBSCRIPTION_SUCCESS, id });
       done();
     })
     .catch(done)
   });
 
  it('dispatches CANCEL_SUBSCRIPTION_FAILURE when it fails', (done) => {
-    const token = 'token_abc';
     const id = 1;
 
     nock(env.API_ROOT)
@@ -41,14 +39,13 @@ describe('subscriptions/cancel', () => {
 
     const store = mockStore({});
 
-    store.dispatch(cancelSubscription(id, token))
+    store.dispatch(cancelSubscription(id))
     .catch(() => {
       const [request, failure] = store.getActions();
 
-      expect(request).toEqual({ type: constants.CANCEL_SUBSCRIPTION_REQUEST, id, token });
+      expect(request).toEqual({ type: constants.CANCEL_SUBSCRIPTION_REQUEST, id });
       expect(failure.type).toEqual(constants.CANCEL_SUBSCRIPTION_FAILURE);
       expect(failure.id).toEqual(id);
-      expect(failure.token).toEqual(token);
       expect(failure.error.message).toContain(`request to http://localhost:3000/api/subscriptions/${id}/cancel failed`);
       done();
     });

--- a/test/unit/actions/subscriptions/get.js
+++ b/test/unit/actions/subscriptions/get.js
@@ -11,7 +11,6 @@ describe('subscriptions/get', () => {
   afterEach(() => nock.cleanAll());
 
   it('dispatches GET_SUBSCRIPTIONS_SUCCESS', (done) => {
-    const token = 'token_abc';
     const subscriptions = [{id: 1}];
 
     nock(env.API_ROOT)
@@ -20,19 +19,18 @@ describe('subscriptions/get', () => {
 
     const store = mockStore({});
 
-    store.dispatch(getSubscriptions(token))
+    store.dispatch(getSubscriptions())
       .then(() => {
         const [request, success] = store.getActions();
 
-        expect(request).toEqual({ type: constants.GET_SUBSCRIPTIONS_REQUEST, token });
-        expect(success).toEqual({ type: constants.GET_SUBSCRIPTIONS_SUCCESS, token, subscriptions });
+        expect(request).toEqual({ type: constants.GET_SUBSCRIPTIONS_REQUEST });
+        expect(success).toEqual({ type: constants.GET_SUBSCRIPTIONS_SUCCESS, subscriptions });
         done();
       })
       .catch(done);
   });
 
  it('dispatches GET_SUBSCRIPTIONS_FAILURE when it fails', (done) => {
-    const token = 'token_abc';
 
     nock(env.API_ROOT)
       .get(`/subscriptions`)
@@ -40,11 +38,11 @@ describe('subscriptions/get', () => {
 
     const store = mockStore({});
 
-    store.dispatch(getSubscriptions(token))
+    store.dispatch(getSubscriptions())
       .then(() => {
         const [request, failure] = store.getActions();
 
-        expect(request).toEqual({ type: constants.GET_SUBSCRIPTIONS_REQUEST, token });
+        expect(request).toEqual({ type: constants.GET_SUBSCRIPTIONS_REQUEST });
         expect(failure.type).toEqual(constants.GET_SUBSCRIPTIONS_FAILURE);
         expect(failure.error.message).toContain('request to http://localhost:3000/api/subscriptions failed');
         done();


### PR DESCRIPTION
This fixes `jwt malformed` error that users are seeing on canceling a subscription. We weren't passing the token properly.