### PR TITLE
Center align n-statistics in CollectiveCard footer

### DIFF
--- a/frontend/src/components/CollectiveCard.js
+++ b/frontend/src/components/CollectiveCard.js
@@ -30,8 +30,6 @@ export default class CollectiveCard extends Component {
       stats.push({ label: i18n.getString('coreContributors'), value: contributorsCount});
     else if (membersCount) {
       stats.push({ label: i18n.getString('members'), value: membersCount });
-    } else {
-      stats.push({ label: ' ', value: ' '});
     }
 
     if (backersAndSponsorsCount) {
@@ -94,9 +92,6 @@ export default class CollectiveCard extends Component {
       stats = this.mapCollectiveCardProps();
     }
 
-    if (stats.length == 2)
-      stats.unshift({label: ' ', value: ' '});
-
     return (
       <div className={`CollectiveCard ${className}`}>
         <a href={publicUrl}>
@@ -113,7 +108,7 @@ export default class CollectiveCard extends Component {
             <div className='CollectiveCard-footer'>
               <div className='clearfix mt2'>
               { stats.map((stat) =>
-                <div key={stat.label} className='col col-4'>
+                <div key={stat.label} className={`col col-${12/(stats.length||1)}`}>
                   <div className='CollectiveCard-metric'>
                     <div className='CollectiveCard-metric-value'>{stat.value}</div>
                     <div className='CollectiveCard-metric-label'>{stat.label}</div>


### PR DESCRIPTION
Currently the className `col col-4` from [basscss](http://www.basscss.com/#basscss-grid) is used to align 3 statistic blocks in the footer. When there are only 2 or 1 available statistic, an empty statistic block is added so alignment is preserved, the available statistic to the left, and two empty statistic blocks to the right.

This fix willl set the className `col col-x` where x is `12/number of statistics`. So no dummy elements are added and statistics are center aligned even when there are 2 or one statistic available to display.