### PR TITLE
Fixes for Discover

### DIFF
--- a/frontend/src/components/discover/DiscoverSelect.js
+++ b/frontend/src/components/discover/DiscoverSelect.js
@@ -21,6 +21,7 @@ export default class DiscoverSelect extends Component {
       opened: false
     }
     this.onClick = this.onClick.bind(this);
+    this.onClickOutsideRef = this.onClickOutside.bind(this);
   }
 
   render() {
@@ -34,7 +35,7 @@ export default class DiscoverSelect extends Component {
           <span className='arrow--bottom'></span>
         </div>
         {opened ? (
-          <div className='DiscoverSelect-menu'>
+          <div className='DiscoverSelect-menu' onClick={e => e.nativeEvent.stopImmediatePropagation()}>
             <ul>
               {options && options.map(option => <li onClick={this.onMenuItemClickMiddleware(option)}>{ option.replace(/\s+/g, nbsp) }</li>)}
             </ul>
@@ -44,8 +45,21 @@ export default class DiscoverSelect extends Component {
     )
   }
 
-  onClick() {
+  componentDidMount() {
+    document.addEventListener('click', this.onClickOutsideRef);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.onClickOutsideRef);
+  }
+
+  onClick(e) {
     this.setState({opened: !this.state.opened});
+    e.nativeEvent.stopImmediatePropagation();
+  }
+
+  onClickOutside() {
+    this.setState({opened: false});
   }
 
   onMenuItemClickMiddleware(option) {
@@ -55,5 +69,4 @@ export default class DiscoverSelect extends Component {
       this.setState({opened: false});
     }
   }
-
 }

--- a/frontend/src/containers/Discover.js
+++ b/frontend/src/containers/Discover.js
@@ -28,15 +28,17 @@ export class Discover extends Component {
   componentDidMount() {
     const { fetchDiscover, fetchGroupTags } = this.props;
     const { currentShowOption, currentSortOption } = this.state;
+    const getScrollTop = () => (window.scrollY || window.pageYOffset || document.body.scrollTop) + (document.documentElement && document.documentElement.scrollTop || 0);
     fetchGroupTags();
     fetchDiscover(currentShowOption, currentSortOption);
     let lastTop = 0xFFFF; // Require scroll towards bottom.
     window.onscroll = debounce(() => {
-      const bottomDirection = lastTop < document.documentElement.scrollTop;
-      if (bottomDirection && document.documentElement.scrollHeight - (window.innerHeight + document.documentElement.scrollTop) < 100) {
+      const scrollTop = getScrollTop();
+      const bottomDirection = lastTop < scrollTop;
+      if (bottomDirection && document.documentElement.scrollHeight - (window.innerHeight + scrollTop) < 100) {
         fetchDiscover(this.state.currentShowOption, this.state.currentSortOption, this.props.discover.collectives.length);
       }
-      lastTop = document.documentElement.scrollTop;
+      lastTop = scrollTop;
     }, 200);
   }
 


### PR DESCRIPTION
1. `DiscoverSelect`'s menu will now hide when clicking anywhere on the document other than the menu. 
2. Discovery Via Scrolling would fail on Chrome because of lack of compatibility, I used the following [StackOverflow answer](http://stackoverflow.com/a/33462363), and confirmed the fix on Chromium and Mozilla Firefox.
