### PR TITLE
Discover can filter based on tag param and query params

### DIFF
--- a/frontend/src/containers/Discover.js
+++ b/frontend/src/containers/Discover.js
@@ -18,7 +18,7 @@ export class Discover extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      currentShowOption: props.show || 'all',
+      currentShowOption: props.params.tag || props.show || 'all',
       currentSortOption: props.sort || 'newest'
     };
     this.onSelectShowOption = this.onSelectShowOption.bind(this);

--- a/frontend/src/containers/Discover.js
+++ b/frontend/src/containers/Discover.js
@@ -18,8 +18,8 @@ export class Discover extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      currentShowOption: 'all',
-      currentSortOption: 'newest'
+      currentShowOption: props.show || 'all',
+      currentSortOption: props.sort || 'newest'
     };
     this.onSelectShowOption = this.onSelectShowOption.bind(this);
     this.onSelectSortOption = this.onSelectSortOption.bind(this);
@@ -108,16 +108,18 @@ export class Discover extends Component {
   }
 }
 
-
 export default connect(mapStateToProps, {
   fetchDiscover,
   fetchGroupTags
 })(Discover);
 
-function mapStateToProps({ discover, groups }) {
+function mapStateToProps({ discover, groups, router }) {
+  const query = router.location.query;
   return {
     discover,
     tags: groups.tags,
-    i18n: i18n('en')
+    i18n: i18n('en'),
+    show: query.show,
+    sort: query.sort,
   }
 }

--- a/frontend/src/containers/HomePage.js
+++ b/frontend/src/containers/HomePage.js
@@ -99,6 +99,7 @@ export class HomePage extends Component {
               i18n={i18n}
               {...group}
             />)}
+            <a href='/discover?show=meetup' className='seemore'>See more meetups</a>
           </div>
           <div className='cta' id='apply'>
             <div className='text'>We are slowly letting in new kinds of collectives</div>

--- a/frontend/src/containers/LoginTopBar.js
+++ b/frontend/src/containers/LoginTopBar.js
@@ -20,7 +20,7 @@ export default class LoginTopBar extends Component {
       <ul className='LoginTopBar-Links'>
         <li><a className='LoginTopBarButton' href='/#apply'>start a collective</a></li>
         <li><a className='LoginTopBarLink' href='/#howitworks'>How it works</a></li>
-        <li><a className='LoginTopBarLink' href='/#opensource'>Discover</a></li>
+        <li><a className='LoginTopBarLink' href='/discover'>Discover</a></li>
       </ul>
     )
   }

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -23,7 +23,7 @@ export default (
     <Route path="/" component={HomePage} />
     <Route path="/about" component={About} />
     <Route path="/faq" component={Faq} />
-    <Route path="/discover" component={Discover} />
+    <Route path="/discover(/:tag)" component={Discover} />
     <Route path="/login/:token" component={Login} />
     <Route path="/login" component={Login} />,
     <Route path="/subscriptions" component={requireAuthentication(Subscriptions)} />

--- a/server/routes.js
+++ b/server/routes.js
@@ -74,7 +74,7 @@ module.exports = (app) => {
    */
   app.get('/', mw.ga, mw.addTitle('OpenCollective - Collect and disburse money transparently'), controllers.homepage, render);
   app.get('/about', mw.ga, mw.addTitle('About'), render);
-  app.get('/discover', mw.ga, mw.addTitle('Discover'), render);
+  app.get('/discover/:tag?', mw.ga, mw.addTitle('Discover'), render);
   app.get('/faq', mw.ga, mw.addTitle('Answers'), render);
   app.get('/login/:token', mw.ga, mw.addTitle('Open Collective'), render);
   app.get('/login', mw.ga, mw.addTitle('Open Collective Login'), render);


### PR DESCRIPTION
For example: 
 `/discover/meetup?sort=oldest`
 `/discover?show=meetup&sort=oldest`

Url Param
**tag** Tag name to filter by (`/discover/:tag`)

Query Params
**show**: Tag name to filter by
**sort**: Sort direction only `oldest` & `newest` are valid, 



Also, `LoginTopBar` was modified so its *Discover* link now points to `/discover` page.