### PR TITLE
Replaced module `babel` with `babel-cli`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "install:debs": "npm run rexec:api install_apt_get_debs.sh"
   },
   "dependencies": {
-    "babel": "5.8.38",
+    "babel-cli": "^6.11.4",
     "babel-core": "6.7.7",
     "babel-eslint": "6.1.2",
     "babel-plugin-add-module-exports": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "install:debs": "npm run rexec:api install_apt_get_debs.sh"
   },
   "dependencies": {
-    "babel-cli": "^6.11.4",
+    "babel-cli": "6.11.4",
     "babel-core": "6.7.7",
     "babel-eslint": "6.1.2",
     "babel-plugin-add-module-exports": "0.1.4",


### PR DESCRIPTION
[CircleCI is failing](https://circleci.com/gh/OpenCollective/opencollective-website/1998) with the following message: 

```
You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.

    npm uninstall babel
    npm install babel-cli

See http://babeljs.io/docs/usage/cli/ for setup instructions.
```
