### PR TITLE
Removed fixed top so it is relative to position

### DIFF
--- a/frontend/src/css/components/DonationDistributor.css
+++ b/frontend/src/css/components/DonationDistributor.css
@@ -244,7 +244,6 @@
 
 .DonationDistributor-disclaimer {
   position: absolute;
-  bottom: -40px;
   h6 {
     margin: 0;
     font-weight: 400;


### PR DESCRIPTION
![preview](https://my.mixtape.moe/yqqnxk.png)

Fix will position disclaimer text relative to its own size, instead of a fixed distance.
(Tested on Chromium and Firefox)