### PR TITLE
showing the title of the expense if any

### DIFF
--- a/frontend/src/components/ExpenseItem.js
+++ b/frontend/src/components/ExpenseItem.js
@@ -16,7 +16,7 @@ const ExpenseItem = ({ className = '', expense, user, i18n }) => {
         <div className='h6 white -fw-bold'>{expense.incurredAt && i18n.moment(expense.incurredAt).fromNow()}</div>
       </div>
       <div className='p2 flex-auto bg-white'>
-        <p className='h5 mt0 mb1'>{expense.category || expense.title}</p>
+        <p className='h5 mt0 mb1'>{expense.title || expense.category}</p>
         <p className='h6 m0 muted'>{i18n.getString('submittedBy')} {user && user.name}</p>
         <div className='mt2'>
           <span className='h3 -ff-sec -fw-bold'>


### PR DESCRIPTION
(instead of just the category which doesn't say much)

![](https://cl.ly/1X2N0Q323R2l/Screen%20Shot%202016-09-12%20at%2010.19.59%20AM.png)

I would add a different field "Notes (private)" as an opportunity to justify the expense in a private way. See https://github.com/OpenCollective/OpenCollective/issues/234