### PR TITLE
Removed explicit height on the .CollectiveCard--name class

### DIFF
--- a/frontend/src/css/components/CollectiveCard.css
+++ b/frontend/src/css/components/CollectiveCard.css
@@ -133,7 +133,7 @@
   }
   .CollectiveCard-body {
     .CollectiveCard-name {
-      height: 29px;
+      min-height: 29px;
       font-family: montserratlight;
       font-size: 22px;
       font-weight: 300;


### PR DESCRIPTION
Not all letters would fit properly
![Bug](https://my.mixtape.moe/nannbm.png)