### PR TITLE
Removed fixed width of submit button

### DIFF
--- a/frontend/src/css/base/input.css
+++ b/frontend/src/css/base/input.css
@@ -8,7 +8,7 @@ input::-webkit-input-placeholder, input::-moz-placeholder, input:-ms-input-place
 /**
  * hide ugly gray gradient
  */
-select, input {
+select, input, textarea {
   -webkit-appearance: none;
 }
 

--- a/frontend/src/css/components/CustomTextArea.css
+++ b/frontend/src/css/components/CustomTextArea.css
@@ -1,10 +1,8 @@
-.CustomTextArea
-{
+.CustomTextArea {
   position: relative;
   display: inline-block;
 
-  .CustomTextArea-textarea
-  {
+  .CustomTextArea-textarea {
     margin: 0;
     box-sizing: border-box;
     width: 100%;
@@ -20,8 +18,7 @@
     letter-spacing: .5px;
   }
 
-  .CustomTextArea-placeholder
-  {
+  .CustomTextArea-placeholder {
     position: absolute;
     left: 0;
     right: 0;
@@ -36,6 +33,7 @@
     font-size: 16px;
     color: #ced5d9;
     cursor: text;
+    background: none;
   }
 
   .CustomTextArea-counter

--- a/frontend/src/css/containers/Transactions.css
+++ b/frontend/src/css/containers/Transactions.css
@@ -83,8 +83,9 @@ body {
 		margin: auto;
 		margin-top: 40px;
 		box-sizing: border-box;
-		width: 350px;
+		max-width: 350px;
 		height: 55px;
+		width: 100%;
 		border-radius: 100px;
 		line-height: 1.75;
 	}


### PR DESCRIPTION
For https://slack-files.com/T0HSL38JD-F2ELW0R1P-53995bb984
@xdamman
On mobile it appears the `box-shadow` for the `CustomTextArea` component is missing. 
This may be a mobile browser quirk since:
 - The bug could not be recreated while on Desktop, w/ Firefox and Chromium in normal and mobile modes.

- All Inputs have the same exact `box-shadow: inset 0 1px 3px 0 rgba(0,0,0,.2);` There is no reason for other elements to render the box-shadow and not the TextArea unless, it was a browser bug.

Fixes:
- Set explicit no background for `CustomTextArea` placeholder element, just to be sure its not being covered by this element.
- There was another minor css issue where the submit button had a fixed width, and would overflow if the screen was less than ~400px in width
- Set `-webkit-appearance: none` for textarea elements, to tackle a possible webkit-only issue explained here http://stackoverflow.com/a/11659325/5244413