### PR TITLE
optimizing image size

### DIFF
--- a/frontend/src/components/CollectiveCard.js
+++ b/frontend/src/components/CollectiveCard.js
@@ -1,6 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 
 import formatCurrency from '../lib/format_currency';
+import { resizeImage } from '../lib/utils';
 
 const DEFAULT_BG = '/static/images/collectives/default-header-bg.jpg';
 const DEFAULT_LOGOS = [
@@ -97,7 +98,7 @@ export default class CollectiveCard extends Component {
         <a href={publicUrl}>
           <div>
             <div className='CollectiveCard-head'>
-              <div className='CollectiveCard-background' style={{backgroundImage: `url(${backgroundImage || DEFAULT_BG})`}}>
+              <div className='CollectiveCard-background' style={{backgroundImage: `url(${resizeImage(backgroundImage, 320) || DEFAULT_BG})`}}>
                 <div className='CollectiveCard-image' style={{backgroundImage: `url(${logo || DEFAULT_LOGOS[key%DEFAULT_LOGOS.length]})`}}></div>
               </div>
             </div>

--- a/frontend/src/components/public_group/PublicGroupHero.js
+++ b/frontend/src/components/public_group/PublicGroupHero.js
@@ -30,7 +30,8 @@ export default class PublicGroupHero extends Component {
     const { group, i18n, session, hasHost, canEditGroup } = this.props;
     const collectiveBg = resizeImage(group.backgroundImage,1024) || DEFAULT_BACKGROUND_IMAGE;
     return (
-      <section className='PublicGroupHero relative px2 bg-black bg-cover white' style={{backgroundImage: `url(${collectiveBg})`}}>
+      <section className='PublicGroupHero relative px2 bg-black bg-cover white'>
+        <div className='backgroundImage' style={{backgroundImage: `url(${collectiveBg})`}} />
         <div className='container relative center'>
           <LoginTopBar loginRedirectTo={ `/${ group.slug }` } />
           <div className='PublicGroupHero-content'>

--- a/frontend/src/components/public_group/PublicGroupHero.js
+++ b/frontend/src/components/public_group/PublicGroupHero.js
@@ -28,10 +28,19 @@ export default class PublicGroupHero extends Component {
 
   render() {
     const { group, i18n, session, hasHost, canEditGroup } = this.props;
-    const collectiveBg = resizeImage(group.backgroundImage,1024) || DEFAULT_BACKGROUND_IMAGE;
+
+    // We can override the default style for the cover image of a group in `group.settings`
+    // e.g. 
+    // - to remove default blur: { "style": { "coverImage": { "filter": "none" }}}
+    // - to make the background monochrome*: { "style": {"coverImage": {"filter":"brightness(50%) sepia(1) hue-rotate(132deg) saturate(103.2%) brightness(91.2%);" }}}
+    // * see http://stackoverflow.com/questions/29037023/how-to-calculate-required-hue-rotate-to-generate-specific-colour
+    group.settings.style = group.settings.style || {};
+    const coverImage = resizeImage(group.backgroundImage,1024) || DEFAULT_BACKGROUND_IMAGE;
+    const coverImageStyle = Object.assign({}, { filter: "blur(4px)", backgroundImage: `url(${coverImage})` }, group.settings.style.coverImage);
+
     return (
       <section className='PublicGroupHero relative px2 bg-black bg-cover white'>
-        <div className='backgroundImage' style={{backgroundImage: `url(${collectiveBg})`}} />
+        <div className='coverImage' style={coverImageStyle} />
         <div className='container relative center'>
           <LoginTopBar loginRedirectTo={ `/${ group.slug }` } />
           <div className='PublicGroupHero-content'>

--- a/frontend/src/components/public_group/PublicGroupHero.js
+++ b/frontend/src/components/public_group/PublicGroupHero.js
@@ -4,6 +4,7 @@ import fetch from 'isomorphic-fetch';
 
 import LoginTopBar from '../../containers/LoginTopBar';
 import exportFile from '../../lib/export_file';
+import { resizeImage } from '../../lib/utils';
 
 const DEFAULT_BACKGROUND_IMAGE = '/static/images/collectives/default-header-bg.jpg';
 
@@ -27,7 +28,7 @@ export default class PublicGroupHero extends Component {
 
   render() {
     const { group, i18n, session, hasHost, canEditGroup } = this.props;
-    const collectiveBg = group.backgroundImage || DEFAULT_BACKGROUND_IMAGE;
+    const collectiveBg = resizeImage(group.backgroundImage,1024) || DEFAULT_BACKGROUND_IMAGE;
     return (
       <section className='PublicGroupHero relative px2 bg-black bg-cover white' style={{backgroundImage: `url(${collectiveBg})`}}>
         <div className='container relative center'>

--- a/frontend/src/css/components/PublicGroupHero.css
+++ b/frontend/src/css/components/PublicGroupHero.css
@@ -47,6 +47,7 @@
   .PublicGroupHero-menu {
     font-size: 13px;
     background-color: rgba(0,0,0,.75);
+    -webkit-backdrop-filter: blur(5px);
     a:hover {
       opacity: .8;
     }

--- a/frontend/src/css/components/PublicGroupHero.css
+++ b/frontend/src/css/components/PublicGroupHero.css
@@ -1,6 +1,13 @@
 .PublicGroupHero {
-  &.bg-cover {
+  .backgroundImage {
+    width: 100%;
+    height: 100%;
+    background-size: cover;
     background-position: 50% 50%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    filter: blur(4px);
   }
   .LoginTopBar {
     background-color: transparent;

--- a/frontend/src/css/components/PublicGroupHero.css
+++ b/frontend/src/css/components/PublicGroupHero.css
@@ -1,5 +1,5 @@
 .PublicGroupHero {
-  .backgroundImage {
+  .coverImage {
     width: 100%;
     height: 100%;
     background-size: cover;
@@ -7,7 +7,6 @@
     position: absolute;
     top: 0;
     left: 0;
-    filter: blur(4px);
   }
   .LoginTopBar {
     background-color: transparent;

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,0 +1,4 @@
+export function resizeImage(imageUrl, width) {
+        if (!imageUrl) return null;
+        return `http://res.cloudinary.com/opencollective/image/fetch/w_${width},c_fill,f_jpg/${encodeURIComponent(imageUrl)}`;
+}


### PR DESCRIPTION
avoid downloading 5MB image to only show a 320px wide version of it in the CollectiveCard.