### PR TITLE
Added border and white bg for hover and focus states

### DIFF
--- a/frontend/src/css/components/ContentEditable.css
+++ b/frontend/src/css/components/ContentEditable.css
@@ -13,10 +13,12 @@ span.editing {
   border: 1px dotted transparent;
   &.ContentEditable--enabled:hover {
     background: white;
+    color: black;
     border: 1px dotted black;
   }
   &.ContentEditable--enabled:focus {
     background: white;
+    color: black;
     border: 1px dotted black; 
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencollective-website",
-  "version": "0.1.178",
+  "version": "0.1.179",
   "engines": {
     "node": "6.2.2",
     "npm": "3.9.5"


### PR DESCRIPTION
When hover over a editable component, it will be surrounded by a dotted border and will have a white background. 
The background and border will persist if the component has focus.