### PR TITLE
Using group.slug instead of group.id to simplify things

### DIFF
--- a/frontend/src/actions/expenses/create.js
+++ b/frontend/src/actions/expenses/create.js
@@ -5,13 +5,13 @@ import * as constants from '../../constants/expenses';
  * Create an expense
  */
 
-export default (groupid, expense) => {
-  const url = `/groups/${groupid}/expenses/`;
+export default (slug, expense) => {
+  const url = `/groups/${slug}/expenses/`;
 
   return dispatch => {
-    dispatch(request(groupid, expense));
+    dispatch(request(slug, expense));
     return postJSON(url, {expense})
-      .then(json => dispatch(success(groupid, json)))
+      .then(json => dispatch(success(slug, json)))
       .catch(error => {
         dispatch(failure(error));
         throw new Error(error.message);
@@ -19,22 +19,22 @@ export default (groupid, expense) => {
   };
 };
 
-function request(groupid, expense) {
+function request(slug, expense) {
   return {
     type: constants.CREATE_EXPENSE_REQUEST,
-    groupid,
+    slug,
     expense
   };
 }
 
-function success(groupid, expense) {
+function success(slug, expense) {
   const expenses = {
     [expense.id]: expense
   };
 
   return {
     type: constants.CREATE_EXPENSE_SUCCESS,
-    groupid,
+    slug,
     expenses
   };
 }

--- a/frontend/src/actions/groups/fetch_by_slug.js
+++ b/frontend/src/actions/groups/fetch_by_slug.js
@@ -6,35 +6,35 @@ import * as constants from '../../constants/groups';
  * Fetch one group
  */
 
-export default (id) => {
+export default (slug) => {
   return dispatch => {
-    dispatch(request(id));
+    dispatch(request(slug));
 
-    return get(`/groups/${id}`, { schema: Schemas.GROUP })
-    .then(json => dispatch(success(id, json)))
-    .catch(error => dispatch(failure(id, error)));
+    return get(`/groups/${slug}`, { schema: Schemas.GROUP })
+    .then(json => dispatch(success(slug, json)))
+    .catch(error => dispatch(failure(slug, error)));
   };
 };
 
-function request(id) {
+function request(slug) {
   return {
     type: constants.GROUP_REQUEST,
-    id
+    slug
   };
 }
 
-export function success(id, json) {
+export function success(slug, json) {
   return {
     type: constants.GROUP_SUCCESS,
-    id,
+    slug,
     groups: json.groups
   };
 }
 
-function failure(id, error) {
+function failure(slug, error) {
   return {
     type: constants.GROUP_FAILURE,
-    id,
+    slug,
     error
   };
 }

--- a/frontend/src/actions/groups/update.js
+++ b/frontend/src/actions/groups/update.js
@@ -5,13 +5,13 @@ import * as constants from '../../constants/groups';
  * Update a group
  */
 
-export default (groupid, group) => {
-  const url = `/groups/${groupid}`;
+export default (slug, group) => {
+  const url = `/groups/${slug}`;
 
   return dispatch => {
-    dispatch(request(groupid, group));
+    dispatch(request(slug, group));
     return putJSON(url, {group})
-      .then(json => dispatch(success(groupid, json)))
+      .then(json => dispatch(success(slug, json)))
       .catch(error => {
         dispatch(failure(error));
         throw new Error(error.message);
@@ -19,18 +19,18 @@ export default (groupid, group) => {
   };
 };
 
-function request(groupid, group) {
+function request(slug, group) {
   return {
     type: constants.UPDATE_GROUP_REQUEST,
-    groupid,
+    slug,
     group
   };
 }
 
-function success(groupid, group) {
+function success(slug, group) {
   return {
     type: constants.UPDATE_GROUP_SUCCESS,
-    groupid,
+    slug,
     group
   };
 }

--- a/frontend/src/actions/groups/updateMembers.js
+++ b/frontend/src/actions/groups/updateMembers.js
@@ -4,14 +4,13 @@ import * as constants from '../../constants/groups';
 /**
  * Update group members
  */
-
-export default (groupid, group) => {
-  const url = `/groups/${groupid}/members`;
+export default (slug, group) => {
+  const url = `/groups/${slug}/members`;
 
   return dispatch => {
-    dispatch(request(groupid, group));
+    dispatch(request(slug, group));
     return putJSON(url, {group})
-      .then(json => dispatch(success(groupid, json)))
+      .then(json => dispatch(success(slug, json)))
       .catch(error => {
         dispatch(failure(error));
         throw new Error(error.message);
@@ -19,18 +18,18 @@ export default (groupid, group) => {
   };
 };
 
-function request(groupid, group) {
+function request(slug, group) {
   return {
     type: constants.UPDATE_GROUP_MEMBERS_REQUEST,
-    groupid,
+    slug,
     group
   };
 }
 
-function success(groupid, group) {
+function success(slug, group) {
   return {
     type: constants.UPDATE_GROUP_MEMBERS_SUCCESS,
-    groupid,
+    slug,
     group
   };
 }

--- a/frontend/src/actions/groups/updateSettings.js
+++ b/frontend/src/actions/groups/updateSettings.js
@@ -5,13 +5,13 @@ import * as constants from '../../constants/groups';
  * Update group settings
  */
 
-export default (groupid, group) => {
-  const url = `/groups/${groupid}/settings`;
+export default (slug, group) => {
+  const url = `/groups/${slug}/settings`;
 
   return dispatch => {
-    dispatch(request(groupid, group));
+    dispatch(request(slug, group));
     return putJSON(url, {group})
-      .then(json => dispatch(success(groupid, json)))
+      .then(json => dispatch(success(slug, json)))
       .catch(error => {
         dispatch(failure(error));
         throw new Error(error.message);
@@ -19,18 +19,18 @@ export default (groupid, group) => {
   };
 };
 
-function request(groupid, group) {
+function request(slug, group) {
   return {
     type: constants.UPDATE_GROUP_REQUEST,
-    groupid,
+    slug,
     group
   };
 }
 
-function success(groupid, group) {
+function success(slug, group) {
   return {
     type: constants.UPDATE_GROUP_SUCCESS,
-    groupid,
+    slug,
     group
   };
 }

--- a/frontend/src/actions/transactions/fetch_by_group.js
+++ b/frontend/src/actions/transactions/fetch_by_group.js
@@ -3,33 +3,32 @@ import Schemas from '../../lib/schemas';
 import * as constants from '../../constants/transactions';
 
 /**
- * Fetch multiple transactions in a group
+ * Fetch transactions from a group
  */
-
-export default (groupid, options={}) => {
+export default (slug, options={}) => {
   return dispatch => {
-    dispatch(request(groupid));
+    dispatch(request(slug));
     const endpoint = options.donation ? 'transactions' : 'expenses';
-    return get(`/groups/${groupid}/${endpoint}`, {
+    return get(`/groups/${slug}/${endpoint}`, {
       schema: Schemas.TRANSACTION_ARRAY,
       params: options || {}
     })
-    .then(json => dispatch(success(groupid, json)))
+    .then(json => dispatch(success(slug, json)))
     .catch(error => dispatch(failure(error)));
   };
 };
 
-function request(groupid) {
+function request(slug) {
   return {
     type: constants.TRANSACTIONS_REQUEST,
-    groupid
+    slug
   };
 }
 
-export function success(groupid, json) {
+export function success(slug, json) {
   return {
     type: constants.TRANSACTIONS_SUCCESS,
-    groupid,
+    slug,
     transactions: json.transactions,
   };
 }

--- a/frontend/src/actions/transactions/fetch_by_id.js
+++ b/frontend/src/actions/transactions/fetch_by_id.js
@@ -5,31 +5,30 @@ import * as constants from '../../constants/transactions';
 /**
  * Fetch one transaction in a group
  */
-
-export default (groupid, transactionid) => {
+export default (slug, transactionid) => {
   return dispatch => {
-    dispatch(request(groupid, transactionid));
+    dispatch(request(slug, transactionid));
 
-    return get(`/groups/${groupid}/transactions/${transactionid}`, {
+    return get(`/groups/${slug}/transactions/${transactionid}`, {
       schema: Schemas.TRANSACTION
     })
-    .then(json => dispatch(success(groupid, transactionid, json)))
+    .then(json => dispatch(success(slug, transactionid, json)))
     .catch(error => dispatch(failure(error)));
   };
 };
 
-function request(groupid, transactionid) {
+function request(slug, transactionid) {
   return {
     type: constants.TRANSACTION_REQUEST,
-    groupid,
+    slug,
     transactionid
   };
 }
 
-function success(groupid, transactionid, json) {
+function success(slug, transactionid, json) {
   return {
     type: constants.TRANSACTION_SUCCESS,
-    groupid,
+    slug,
     transactionid,
     transactions: json.transactions,
   };

--- a/frontend/src/actions/users/fetch_by_group.js
+++ b/frontend/src/actions/users/fetch_by_group.js
@@ -2,29 +2,28 @@ import { get } from '../../lib/api';
 import * as constants from '../../constants/users';
 
 /**
- * Fetch multiple users in a group
+ * Fetch users from a group
  */
-
-export default (groupid) => {
+export default (slug) => {
   return dispatch => {
-    dispatch(request(groupid));
-    return get(`/groups/${groupid}/users`)
-    .then(json => dispatch(success(groupid, json)))
+    dispatch(request(slug));
+    return get(`/groups/${slug}/users`)
+    .then(json => dispatch(success(slug, json)))
     .catch(error => dispatch(failure(error)));
   };
 };
 
-function request(groupid) {
+function request(slug) {
   return {
     type: constants.FETCH_USERS_BY_GROUP_REQUEST,
-    groupid
+    slug
   };
 }
 
-function success(groupid, json) {
+function success(slug, json) {
   return {
     type: constants.FETCH_USERS_BY_GROUP_SUCCESS,
-    groupid,
+    slug,
     users: json
   };
 }

--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -12,10 +12,12 @@ import reduxMiddleware from './redux_middleware';
 import decodeJWT from './actions/session/decode_jwt';
 import initialRender from './actions/app/initial_render';
 
-const store = compose(
+const store = createStore(reducers, window.__INITIAL_STATE__, compose(
   reduxReactRouter({ createHistory, routes }),
-  applyMiddleware(...reduxMiddleware)
-)(createStore)(reducers, window.__INITIAL_STATE__);
+  applyMiddleware(...reduxMiddleware),
+  window.devToolsExtension ? window.devToolsExtension() : f => f
+));
+
 
 // Decode token if stored in localStorage
 store.dispatch(decodeJWT());

--- a/frontend/src/components/ContentEditable.js
+++ b/frontend/src/components/ContentEditable.js
@@ -13,11 +13,11 @@ export default class ContentEditable extends React.Component {
   render() {
     const { disabled, format, className, tagName, ...props } = this.props;
 
+    const html = this.props.html || '';
+
     if (format === 'markdown' && disabled) {
       return (<Markdown {...this.props} value={html} />);
     }
-
-    const html = this.props.html || '';
 
     return React.createElement(
       tagName || 'div',

--- a/frontend/src/components/public_group/AmountPicker.js
+++ b/frontend/src/components/public_group/AmountPicker.js
@@ -23,6 +23,14 @@ export default class AmountPicker extends React.Component {
       {id: group.id, name: group.name, logo: group.logo},
     ];
 
+    // xdamman: 
+    // When the PublicGroup container is displayed after a pushState (e.g. after login)
+    // it tries to render this component before the group.currency is loaded.
+    // Once that variable is set, the child component <DonationDistributor /> doesn't update.
+    // As a result, the backer tier shows a disabled button
+    // This fixes this bug. But I'm not happy with it.
+    if (!currency) return (<div />);
+
     return (
       <div>
         {tier.presets && (

--- a/frontend/src/components/public_group/PublicGroupHero.js
+++ b/frontend/src/components/public_group/PublicGroupHero.js
@@ -33,7 +33,6 @@ export default class PublicGroupHero extends Component {
 
   render() {
     const { group, i18n, session, hasHost, canEditGroup, groupForm, appendEditGroupForm} = this.props;
-
     const titles = Object.keys(processMarkdown(group.longDescription));
 
     const getAnchor = (title) => {
@@ -55,16 +54,18 @@ export default class PublicGroupHero extends Component {
         <div className='container relative center'>
           <LoginTopBar loginRedirectTo={ `/${ group.slug }` } />
           <div className='PublicGroupHero-content'>
-            <UserPhoto
-              editable={canEditGroup}
-              onChange={logo => {
-                if (logo !== group.logo)
-                  return appendEditGroupForm({logo})
-              }}
-              user={{ avatar: groupForm.attributes.logo || group.logo }}
-              className='PublicGroupHero-logo mb3 bg-contain'
-              presets={[]}
-              {...this.props} />
+            {group.logo &&
+              <UserPhoto
+                editable={canEditGroup}
+                onChange={logo => {
+                  if (logo !== group.logo)
+                    return appendEditGroupForm({logo})
+                }}
+                user={{ avatar: groupForm.attributes.logo || group.logo }}
+                className='PublicGroupHero-logo mb3 bg-contain'
+                presets={[]}
+                {...this.props} />
+            }
 
             <p ref='PublicGroupHero-name' className='PublicGroup-font-20 mt0 mb2'>{ i18n.getString('hiThisIs') }
               <a href={ group.website }> { group.name }</a> { i18n.getString('openCollective') }.

--- a/frontend/src/components/public_group/PublicGroupWhoWeAre.js
+++ b/frontend/src/components/public_group/PublicGroupWhoWeAre.js
@@ -49,7 +49,7 @@ export default class PublicGroupWhoWeAre extends Component {
             {group.longDescription && (
               <ContentEditable
                 className='ContentEditable-long-description'
-                html={group.longDescription}
+                html={ (longDescription === '' || longDescription) ? longDescription : group.longDescription }
                 format='markdown'
                 disabled={ !canEditGroup }
                 onChange={ event => appendEditGroupForm({longDescription: event.target.value}) }

--- a/frontend/src/components/public_group/PublicGroupWhoWeAre.js
+++ b/frontend/src/components/public_group/PublicGroupWhoWeAre.js
@@ -49,7 +49,7 @@ export default class PublicGroupWhoWeAre extends Component {
             {group.longDescription && (
               <ContentEditable
                 className='ContentEditable-long-description'
-                html={ (longDescription === '' || longDescription) ? longDescription : group.longDescription }
+                html={group.longDescription}
                 format='markdown'
                 disabled={ !canEditGroup }
                 onChange={ event => appendEditGroupForm({longDescription: event.target.value}) }

--- a/frontend/src/containers/DonatePage.js
+++ b/frontend/src/containers/DonatePage.js
@@ -15,7 +15,7 @@ import PublicGroupSignup from '../components/public_group/PublicGroupSignupV2';
 import Tiers from '../components/Tiers';
 import getTier from '../lib/tiers';
 
-import fetchGroup from '../actions/groups/fetch_by_id';
+import fetchGroup from '../actions/groups/fetch_by_slug';
 import fetchUsers from '../actions/users/fetch_by_group';
 import donate from '../actions/groups/donate';
 import notify from '../actions/notification/notify';
@@ -91,9 +91,8 @@ export class DonatePage extends Component {
       fetchGroup
     } = this.props;
 
-    fetchGroup(group.id);
-
-    fetchUsers(group.id);
+    fetchGroup(group.slug);
+    fetchUsers(group.slug);
   }
 
   componentDidMount() {

--- a/frontend/src/containers/PublicGroup.js
+++ b/frontend/src/containers/PublicGroup.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 
 import sortBy from 'lodash/sortBy';
 import take from 'lodash/take';
-import values from 'lodash/values';
 import merge from 'lodash/merge';
 
 import filterCollection from '../lib/filter_collection';

--- a/frontend/src/containers/PublicGroup.js
+++ b/frontend/src/containers/PublicGroup.js
@@ -17,7 +17,7 @@ import appendDonationForm from '../actions/form/append_donation';
 import appendProfileForm from '../actions/form/append_profile';
 import decodeJWT from '../actions/session/decode_jwt';
 import donate from '../actions/groups/donate';
-import fetchGroup from '../actions/groups/fetch_by_id';
+import fetchGroup from '../actions/groups/fetch_by_slug';
 import fetchProfile from '../actions/profile/fetch_by_slug';
 import fetchTransactions from '../actions/transactions/fetch_by_group';
 import fetchUsers from '../actions/users/fetch_by_group';
@@ -201,28 +201,28 @@ export class PublicGroup extends Component {
   }
 
   componentDidMount() {
+    const promises = [];
     const {
+      slug,
+      transactions,
       group,
       fetchTransactions,
       fetchUsers,
       fetchGroup
     } = this.props;
 
-    return Promise.all([
-      fetchGroup(group.id),
-      fetchTransactions(group.id, FETCH_DONATIONS_OPTIONS),
-      fetchTransactions(group.id, FETCH_EXPENSES_OPTIONS),
-      fetchUsers(group.id)
-    ])
+    if (!group.name) promises.push(fetchGroup(slug));
+    if (!group.usersByRole) promises.push(fetchUsers(slug));
+    if (!transactions) promises.push(fetchTransactions(slug, FETCH_DONATIONS_OPTIONS));
+    if (!transactions) promises.push(fetchTransactions(slug, FETCH_EXPENSES_OPTIONS));
+
+    Promise.all(promises).then();
   }
 
   componentWillMount() {
     const {
       paypalIsDone,
       hasFullAccount,
-      slug,
-      fetchProfile,
-      loadData
     } = this.props;
 
     if (paypalIsDone) {
@@ -231,10 +231,6 @@ export class PublicGroup extends Component {
         showUserForm: !hasFullAccount,
         showThankYouMessage: hasFullAccount
       });
-    }
-
-    if (loadData) {
-      fetchProfile(slug);
     }
   }
 
@@ -248,16 +244,17 @@ export class PublicGroup extends Component {
   // Used after a donation
   refreshData() {
     const {
-      group,
-      fetchGroup,
+      slug,
+      fetchProfile,
       fetchUsers,
       fetchTransactions
     } = this.props;
 
     return Promise.all([
-      fetchGroup(group.id),
-      fetchUsers(group.id),
-      fetchTransactions(group.id, FETCH_DONATIONS_OPTIONS)
+      fetchProfile(slug),
+      fetchTransactions(slug, FETCH_DONATIONS_OPTIONS),
+      fetchTransactions(slug, FETCH_EXPENSES_OPTIONS),
+      fetchUsers(slug)
     ]);
   }
 }
@@ -265,8 +262,8 @@ export class PublicGroup extends Component {
 export function donateToGroup({amount, frequency, currency, token, options}) {
   const {
     notify,
+    slug,
     donate,
-    group
   } = this.props;
 
   const payment = {
@@ -283,7 +280,7 @@ export function donateToGroup({amount, frequency, currency, token, options}) {
     payment.interval = 'year';
   }
 
-  return donate(group.id, payment, options)
+  return donate(slug, payment, options)
     .then(() => {
       // Paypal will redirect to this page and we will refresh at that moment.
       // A Stripe donation on the other hand is immediate after the request:
@@ -307,7 +304,7 @@ export function saveNewUser() {
     profileForm,
     validateSchema,
     notify,
-    group,
+    slug,
     fetchUsers
   } = this.props;
 
@@ -320,7 +317,7 @@ export function saveNewUser() {
       showUserForm: false,
       showThankYouMessage: true
     }))
-    .then(() => fetchUsers(group.id))
+    .then(() => fetchUsers(slug))
     .catch(({message}) => notify('error', message));
 }
 
@@ -337,7 +334,7 @@ export function saveGroup() {
   } = this.props;
 
   return validateSchema(groupForm.attributes, editGroupSchema)
-    .then(() => updateGroup(group.id, groupForm.attributes))
+    .then(() => updateGroup(slug, groupForm.attributes))
     .then(() => merge(group, groupForm.attributes)) // this is to prevent ui from temporarily reverting to old text
     .then(() => cancelEditGroupForm()) // clear out this form to prevent data issues on another page.
     .then(() => fetchProfile(slug))
@@ -382,6 +379,8 @@ function mapStateToProps({
   app
 }) {
   const { query } = router.location;
+  const slug = router.params.slug;
+
   const newUserId = query.userid;
   const paypalUser = {
     id: query.userid,
@@ -389,8 +388,7 @@ function mapStateToProps({
   };
 
   const newUser = users.newUser || paypalUser;
-
-  const group = values(groups)[0] || {stripeAccount: {}}; // to refactor to allow only one group
+  const group = groups[slug] || {stripeAccount: {}}; // to refactor to allow only one group
   const usersByRole = group.usersByRole || {};
 
   /* @xdamman:
@@ -406,6 +404,9 @@ function mapStateToProps({
   group.transactions = filterCollection(transactions, { GroupId: group.id });
   group.tiers = group.tiers || DEFAULT_GROUP_TIERS;
   group.settings = group.settings || DEFAULT_GROUP_SETTINGS;
+
+  if (group.name && window.document) 
+    document.title = `${group.name} is on Open Collective`;
 
   const donations = transactions.isDonation;
   const expenses = transactions.isExpense;
@@ -427,7 +428,7 @@ function mapStateToProps({
     newUser,
     hasFullAccount: newUser.hasFullAccount || false,
     i18n: i18n(group.settings.lang || 'en'),
-    slug: router.params.slug,
+    slug,
     loadData: app.rendered,
     isSupercollective: group.isSupercollective,
     hasHost: group.hosts.length === 0 ? false : true,

--- a/frontend/src/containers/SubmitExpense.js
+++ b/frontend/src/containers/SubmitExpense.js
@@ -19,7 +19,7 @@ import i18n from '../lib/i18n';
 import roles from '../constants/roles';
 import PublicGroupThanks from '../components/PublicGroupThanks';
 
-import fetchGroup from '../actions/groups/fetch_by_id';
+import fetchGroup from '../actions/groups/fetch_by_slug';
 import notify from '../actions/notification/notify';
 import resetNotifications from '../actions/notification/reset';
 import decodeJWT from '../actions/session/decode_jwt';
@@ -62,7 +62,7 @@ export class SubmitExpense extends Component {
       fetchGroup
     } = this.props;
 
-    fetchGroup(group.id);
+    fetchGroup(group.slug);
 
   }
 
@@ -94,7 +94,7 @@ export function createExpenseFn() {
       // TODO should be specified by user
       currency: group.currency
     };
-    return createExpense(group.id, newExpense);
+    return createExpense(group.slug, newExpense);
   })
   .then(() => {
     window.scrollTo(0, 0);
@@ -143,8 +143,8 @@ function mapStateToProps({form, notification, images, groups}) {
     group,
     notification,
     expense,
-    categories: categories(group.id),
-    enableVAT: vats(group.id),
+    categories: categories(group.slug),
+    enableVAT: vats(group.slug),
     isUploading: images.isUploading || false,
     i18n: i18n(group.settings.lang || 'en')
   };

--- a/frontend/src/containers/Transactions.js
+++ b/frontend/src/containers/Transactions.js
@@ -103,9 +103,9 @@ export class Transactions extends Component {
       [type]: true
     };
 
-    fetchTransactions(group.id, options);
+    fetchTransactions(group.slug, options);
 
-    fetchUsers(group.id);
+    fetchUsers(group.slug);
   }
 
   componentDidMount() {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -9,7 +9,6 @@ const { API_ROOT } = env;
 /**
  * Get request
  */
-
 export function get(endpoint, options={}) {
   const { schema, params } = options;
 
@@ -32,7 +31,6 @@ export function getThirdParty(endpoint, options={}) {
 /**
  * POST json request
  */
-
 export function postJSON(endpoint, body, options={}) {
   let headers = {
       Accept: 'application/json',
@@ -56,7 +54,6 @@ export function postJSON(endpoint, body, options={}) {
 /**
  * PUT json request
  */
-
 export function putJSON(endpoint, body) {
   return fetch(url(endpoint), {
     method: 'put',
@@ -72,7 +69,6 @@ export function putJSON(endpoint, body) {
 /**
  * POST request
  */
-
 export function post(endpoint, body, options={}) {
   return fetch(url(endpoint), {
     headers: addAuthTokenToHeader(options.headers),
@@ -85,7 +81,6 @@ export function post(endpoint, body, options={}) {
 /**
  * DELETE request
  */
-
 export function del(endpoint) {
   return fetch(url(endpoint), {
     headers: addAuthTokenToHeader(),
@@ -97,7 +92,6 @@ export function del(endpoint) {
 /**
  * Build url to the api
  */
-
 function url(endpoint, params) {
   const query = queryString.stringify(params);
 
@@ -117,7 +111,6 @@ function urlThirdParty(endpoint, params) {
  * The Promise returned from fetch() won't reject on HTTP error status. We
  * need to throw an error ourselves.
  */
-
 export function checkStatus(response) {
   const { status } = response;
 

--- a/frontend/src/lib/schemas.js
+++ b/frontend/src/lib/schemas.js
@@ -4,7 +4,7 @@ import { Schema, arrayOf } from 'normalizr';
  * Schemas
  */
 
-const GroupSchema = new Schema('groups');
+const GroupSchema = new Schema('groups', { idAttribute: 'slug' });
 const TransactionSchema = new Schema('transactions');
 const UserSchema = new Schema('users');
 const CardSchema = new Schema('cards');

--- a/frontend/src/reducers/groups.js
+++ b/frontend/src/reducers/groups.js
@@ -12,7 +12,7 @@ export default function groups(state={}, action={}) {
     case HYDRATE:
       if (action.data.group) {
         return merge({}, state, {
-          [action.data.group.id]: action.data.group
+          [action.data.group.slug]: action.data.group
         });
       } else if (action.data.leaderboard) {
         return merge({}, state, {
@@ -35,7 +35,7 @@ export default function groups(state={}, action={}) {
       const users = values(action.users);
 
       return merge({}, state, {
-        [action.groupid]: {
+        [action.slug]: {
           usersByRole: groupBy(users, 'role')
         }
       });

--- a/frontend/src/reducers/transactions.js
+++ b/frontend/src/reducers/transactions.js
@@ -22,4 +22,3 @@ export default function transactions(state={
       return state;
   }
 }
-

--- a/frontend/src/ui/expenseCategories.js
+++ b/frontend/src/ui/expenseCategories.js
@@ -1,67 +1,16 @@
 /**
  * Static data the for the expense form
  */
-
-export default function(groupid) {
-  if (typeof groupid == "string")
-    groupid = parseInt(groupid, 10);
+export default function(slug = '') {
 
   let categories = [];
-  switch (groupid) {
+  let base_slug = slug;
+  if (slug.match(/^wwcode/))
+    base_slug = 'wwcode';
+
+  switch (base_slug) {
     // Women Who Code
-    case 2:
-    case 3:
-    case 4:
-    case 10:
-    case 12:
-    case 13:
-    case 14:
-    case 15:
-    case 47:
-    case 48:
-    case 51:
-    case 59:
-    case 195:
-    case 241:
-    case 259:
-    case 260:
-    case 261:
-    case 262:
-    case 263:
-    case 266:
-    case 267:
-    case 268:
-    case 269:
-    case 270:
-    case 271:
-    case 272:
-    case 273:
-    case 274:
-    case 275:
-    case 276:
-    case 277:
-    case 278:
-    case 279:
-    case 280:
-    case 281:
-    case 282:
-    case 283:
-    case 284:
-    case 285:
-    case 286:
-    case 287:
-    case 288:
-    case 289:
-    case 290:
-    case 292:
-    case 293:
-    case 294:
-    case 295:
-    case 297:
-    case 298:
-    case 299:
-    case 300:
-    case 301:
+    case 'wwcode':
       categories = [
         'Conference',
         'Donation',
@@ -84,9 +33,9 @@ export default function(groupid) {
         'Other'
       ];
       break;
-    case 6: // laprimaire
-    case 73: // nuitdebout
-    case 24: // lesbarbares
+    case 'laprimaire': // laprimaire
+    case 'nuitdebout': // nuitdebout
+    case 'lesbarbares': // lesbarbares
       categories = [
         'Admin',
         'Autre',
@@ -102,7 +51,7 @@ export default function(groupid) {
         'Transport'
       ];
        break;
-    case 114: // partidodigital
+    case 'partidodigital':
       categories = [
         'Comunicación',
         'Diseño',
@@ -120,7 +69,7 @@ export default function(groupid) {
         'Servicios Digitales'
       ];
       break;
-    case 245: // analizebasilicata
+    case 'analizebasilicata':
       categories = [
         'Comunicazioni',
         'Disign',

--- a/frontend/src/ui/vat.js
+++ b/frontend/src/ui/vat.js
@@ -1,16 +1,12 @@
 /**
  * Static data the for the transaction form
  */
-
-export default function(groupid) {
-  if (typeof groupid == "string")
-    groupid = parseInt(groupid, 10);
-
+export default function(slug) {
   let vat = false;
-  switch (groupid) {
-    case 6: // laprimaire
-    case 73: // nuitdebout
-    case 24: // lesbarbares
+  switch (slug) {
+    case 'laprimaire':
+    case 'nuitbout':
+    case 'lesbarbares':
       vat = true;
       break;
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,6 +34,9 @@ push_to_repo() {
   # get the latest from_branch
   get_latest_branch $from_branch
 
+  # clean local branches that have been merged
+  npm run git:clean
+
   if [ $patch = "1" ]
   then
     npm version patch

--- a/test/unit/actions/groups/fetch_by_slug.js
+++ b/test/unit/actions/groups/fetch_by_slug.js
@@ -27,8 +27,8 @@ describe('groups/fetch_by_slug', () => {
     store.dispatch(fetchBySlug(group.slug))
     .then(() => {
       const [request, success] = store.getActions();
-      expect(request).toEqual({ type: constants.GROUP_REQUEST, id: 1 });
-      expect(success).toEqual({ type: constants.GROUP_SUCCESS, id: 1, groups: { 'testgroup' : group} });
+      expect(request).toEqual({ type: constants.GROUP_REQUEST, slug: group.slug });
+      expect(success).toEqual({ type: constants.GROUP_SUCCESS, slug: group.slug, groups: { [group.slug] : group} });
       done();
     })
     .catch(done)
@@ -44,10 +44,10 @@ describe('groups/fetch_by_slug', () => {
     store.dispatch(fetchBySlug(group.slug))
     .then(() => {
       const [request, failure] = store.getActions();
-      expect(request).toEqual({ type: constants.GROUP_REQUEST, id: 1 });
+      expect(request).toEqual({ type: constants.GROUP_REQUEST, slug: group.slug });
       expect(failure.type).toEqual(constants.GROUP_FAILURE);
-      expect(failure.id).toEqual(1);
-      expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1 failed');
+      expect(failure.slug).toEqual(group.slug);
+      expect(failure.error.message).toContain(`request to http://localhost:3000/api/groups/${group.slug} failed`);
       done();
     })
     .catch(done)

--- a/test/unit/actions/groups/fetch_by_slug.js
+++ b/test/unit/actions/groups/fetch_by_slug.js
@@ -3,30 +3,32 @@ import expect from 'expect';
 
 import mockStore from '../../helpers/mockStore';
 import env from '../../../../frontend/src/lib/env';
-import fetchById from '../../../../frontend/src/actions/groups/fetch_by_id';
+import fetchBySlug from '../../../../frontend/src/actions/groups/fetch_by_slug';
 import * as constants from '../../../../frontend/src/constants/groups';
 
-describe('groups/fetch_by_id', () => {
+const group = {
+  id: 1,
+  slug: 'testgroup',
+  description: 'happy stuff'
+};
+
+describe('groups/fetch_by_slug', () => {
 
   afterEach(() => nock.cleanAll());
 
   it('creates GROUP_SUCCESS when fetching a group is done', (done) => {
-    const group = {
-      id: 1,
-      description: 'happy stuff'
-    };
 
     nock(env.API_ROOT)
-      .get('/groups/1')
+      .get(`/groups/${group.slug}`)
       .reply(200, group);
 
     const store = mockStore({});
 
-    store.dispatch(fetchById(1))
+    store.dispatch(fetchBySlug(group.slug))
     .then(() => {
       const [request, success] = store.getActions();
       expect(request).toEqual({ type: constants.GROUP_REQUEST, id: 1 });
-      expect(success).toEqual({ type: constants.GROUP_SUCCESS, id: 1, groups: {1: group} });
+      expect(success).toEqual({ type: constants.GROUP_SUCCESS, id: 1, groups: { 'testgroup' : group} });
       done();
     })
     .catch(done)
@@ -34,12 +36,12 @@ describe('groups/fetch_by_id', () => {
 
   it('creates GROUP_ERROR when fetching a group fails', (done) => {
     nock(env.API_ROOT)
-      .get('/groups/1')
+      .get(`/groups/${group.slug}`)
       .replyWithError('');
 
     const store = mockStore({});
 
-    store.dispatch(fetchById(1))
+    store.dispatch(fetchBySlug(group.slug))
     .then(() => {
       const [request, failure] = store.getActions();
       expect(request).toEqual({ type: constants.GROUP_REQUEST, id: 1 });

--- a/test/unit/actions/transactions/fetch_by_group.js
+++ b/test/unit/actions/transactions/fetch_by_group.js
@@ -14,37 +14,37 @@ describe('transactions/fetch_by_group actions', () => {
       id: 2,
       amount: 999
     };
-    const groupid = 1;
+    const slug = 'testgroup';
 
     nock(env.API_ROOT)
-      .get(`/groups/${groupid}/expenses`)
+      .get(`/groups/${slug}/expenses`)
       .reply(200, [transaction]);
 
     const store = mockStore({});
 
-    store.dispatch(fetchByGroup(groupid))
+    store.dispatch(fetchByGroup(slug))
     .then(() => {
       const [request, success] = store.getActions();
-      expect(request).toEqual({ type: constants.TRANSACTIONS_REQUEST, groupid })
-      expect(success).toEqual({ type: constants.TRANSACTIONS_SUCCESS, groupid, transactions: { 2: transaction } })
+      expect(request).toEqual({ type: constants.TRANSACTIONS_REQUEST, slug })
+      expect(success).toEqual({ type: constants.TRANSACTIONS_SUCCESS, slug, transactions: { 2: transaction } })
       done();
     })
     .catch(done)
   });
 
   it('creates TRANSACTIONS_FAILURE if it fails', (done) => {
-    const groupid = 1;
+    const slug = 1;
 
     nock(env.API_ROOT)
-      .get(`/groups/${groupid}/expenses`)
+      .get(`/groups/${slug}/expenses`)
       .replyWithError('');
 
     const store = mockStore({});
 
-    store.dispatch(fetchByGroup(groupid))
+    store.dispatch(fetchByGroup(slug))
     .then(() => {
       const [request, failure] = store.getActions();
-      expect(request).toEqual({ type: constants.TRANSACTIONS_REQUEST, groupid });
+      expect(request).toEqual({ type: constants.TRANSACTIONS_REQUEST, slug });
       expect(failure.type).toEqual(constants.TRANSACTIONS_FAILURE);
       expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1/expenses failed');
       done();

--- a/test/unit/actions/transactions/fetch_by_id.js
+++ b/test/unit/actions/transactions/fetch_by_id.js
@@ -15,23 +15,23 @@ describe('transactions/fetch_by_id', () => {
       id: 2,
       amount: 999
     };
-    const groupid = 1;
+    const slug = 'testgroup';
     const transactionid = transaction.id;
 
     nock(env.API_ROOT)
-      .get(`/groups/${groupid}/transactions/${transactionid}`)
+      .get(`/groups/${slug}/transactions/${transactionid}`)
       .reply(200, transaction);
 
     const store = mockStore({});
 
-    store.dispatch(fetchById(groupid, transactionid))
+    store.dispatch(fetchById(slug, transactionid))
     .then(() => {
       const [request, success] = store.getActions();
 
-      expect(request).toEqual({ type: constants.TRANSACTION_REQUEST, groupid, transactionid });
+      expect(request).toEqual({ type: constants.TRANSACTION_REQUEST, slug, transactionid });
       expect(success).toEqual({
         type: constants.TRANSACTION_SUCCESS,
-        groupid,
+        slug,
         transactionid,
         transactions: { 2: transaction }
       });
@@ -46,20 +46,20 @@ describe('transactions/fetch_by_id', () => {
       id: 2,
       amount: 999
     };
-    const groupid = 1;
+    const slug = 1;
     const transactionid = transaction.id;
 
     nock(env.API_ROOT)
-      .get(`/groups/${groupid}/transactions/${transactionid}`)
+      .get(`/groups/${slug}/transactions/${transactionid}`)
       .replyWithError('');
 
     const store = mockStore({});
 
-    store.dispatch(fetchById(groupid, transactionid))
+    store.dispatch(fetchById(slug, transactionid))
     .then(() => {
       const [request, failure] = store.getActions();
 
-      expect(request).toEqual({ type: constants.TRANSACTION_REQUEST, groupid, transactionid });
+      expect(request).toEqual({ type: constants.TRANSACTION_REQUEST, slug, transactionid });
       expect(failure.type).toEqual(constants.TRANSACTION_FAILURE);
       expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1/transactions/2 failed');
       done();

--- a/test/unit/actions/users/fetch_by_group.js
+++ b/test/unit/actions/users/fetch_by_group.js
@@ -15,37 +15,37 @@ describe('users/fetch_by_group', () => {
       id: 2,
       name: 'Jeff'
     };
-    const groupid = 1;
+    const slug = 'testgroup';
 
     nock(env.API_ROOT)
-      .get(`/groups/${groupid}/users`)
+      .get(`/groups/${slug}/users`)
       .reply(200, [user]);
 
     const store = mockStore({});
 
-    store.dispatch(fetchByGroup(groupid))
+    store.dispatch(fetchByGroup(slug))
     .then(() => {
       const [request, success] = store.getActions();
-      expect(request).toEqual({ type: constants.FETCH_USERS_BY_GROUP_REQUEST, groupid })
-      expect(success).toEqual({ type: constants.FETCH_USERS_BY_GROUP_SUCCESS, groupid, users: [user] })
+      expect(request).toEqual({ type: constants.FETCH_USERS_BY_GROUP_REQUEST, slug })
+      expect(success).toEqual({ type: constants.FETCH_USERS_BY_GROUP_SUCCESS, slug, users: [user] })
       done();
     })
     .catch(done)
   });
 
   it('return FETCH_USERS_BY_GROUP_FAILURE if it fails', (done) => {
-    const groupid = 1;
+    const slug = 1;
 
     nock(env.API_ROOT)
-      .get(`/groups/${groupid}/users`)
+      .get(`/groups/${slug}/users`)
       .replyWithError('');
 
     const store = mockStore({});
 
-    store.dispatch(fetchByGroup(groupid))
+    store.dispatch(fetchByGroup(slug))
     .then(() => {
       const [request, failure] = store.getActions();
-      expect(request).toEqual({ type: constants.FETCH_USERS_BY_GROUP_REQUEST, groupid });
+      expect(request).toEqual({ type: constants.FETCH_USERS_BY_GROUP_REQUEST, slug });
       expect(failure.type).toEqual(constants.FETCH_USERS_BY_GROUP_FAILURE);
       expect(failure.error.message).toContain('request to http://localhost:3000/api/groups/1/users failed');
       done();

--- a/test/unit/containers/PublicGroup.js
+++ b/test/unit/containers/PublicGroup.js
@@ -27,6 +27,7 @@ const setup = () => {
 
   const group = {
     id: 1,
+    slug: 'testgroup',
     currency: 'MXN',
     host: { name: 'WWCode', website: 'http://womenwhocode.com' }
   };
@@ -54,7 +55,7 @@ describe('PublicGroup container', () => {
     const { currency } = group;
 
     const donate = chai.spy((slug, payment) => {
-      expect(slug).to.be.equal('testgroup');
+      expect(slug).to.be.equal(group.slug);
       expect(payment.currency).to.be.equal('MXN');
       expect(payment.email).to.be.equal(token.email);
       expect(payment.amount).to.be.equal(10);
@@ -66,6 +67,7 @@ describe('PublicGroup container', () => {
       ...actions,
       donate,
       group,
+      slug: group.slug,
       currency
     };
 
@@ -89,7 +91,7 @@ describe('PublicGroup container', () => {
     const { actions, group, setState, refreshData, token } = setup();
 
     const donate = chai.spy((slug, payment) => {
-      expect(slug).to.be.equal('testgroup');
+      expect(slug).to.be.equal(group.slug);
       expect(payment.interval).to.be.equal('month');
       expect(payment.stripeToken).to.be.equal(token.id);
       expect(payment.email).to.be.equal(token.email);
@@ -102,6 +104,7 @@ describe('PublicGroup container', () => {
       ...actions,
       donate,
       group,
+      slug: group.slug,
       frequency: 'monthly'
     };
 

--- a/test/unit/containers/PublicGroup.js
+++ b/test/unit/containers/PublicGroup.js
@@ -53,8 +53,8 @@ describe('PublicGroup container', () => {
     const { actions, group, setState, refreshData, token } = setup();
     const { currency } = group;
 
-    const donate = chai.spy((groupid, payment) => {
-      expect(groupid).to.be.equal(1);
+    const donate = chai.spy((slug, payment) => {
+      expect(slug).to.be.equal('testgroup');
       expect(payment.currency).to.be.equal('MXN');
       expect(payment.email).to.be.equal(token.email);
       expect(payment.amount).to.be.equal(10);
@@ -88,8 +88,8 @@ describe('PublicGroup container', () => {
   it('should donate with subscription to the group', (done) => {
     const { actions, group, setState, refreshData, token } = setup();
 
-    const donate = chai.spy((groupid, payment) => {
-      expect(groupid).to.be.equal(1);
+    const donate = chai.spy((slug, payment) => {
+      expect(slug).to.be.equal('testgroup');
       expect(payment.interval).to.be.equal('month');
       expect(payment.stripeToken).to.be.equal(token.id);
       expect(payment.email).to.be.equal(token.email);

--- a/test/unit/reducers/groups.js
+++ b/test/unit/reducers/groups.js
@@ -32,7 +32,7 @@ describe('groups reducer', () => {
       id: 2,
       role: 'BACKER'
     };
-    const groupid = 9;
+    const slug = 'testgroup';
 
     const state = reducer(undefined, {
       type: FETCH_USERS_BY_GROUP_SUCCESS,
@@ -40,11 +40,11 @@ describe('groups reducer', () => {
         1: member,
         2: backer
       },
-      groupid
+      slug
     });
 
     expect(state).toEqual({
-      [groupid]: {
+      [slug]: {
         usersByRole: {
           MEMBER: [member],
           BACKER: [backer]


### PR DESCRIPTION
Slug is also a unique idea but it has the benefit of always being available in the URL.

This also makes it easier to handle the case of the redirect after login with `pushState`.
Today, it doesn't work and it shows a group page that is empty (the user needs to hard refresh the page). That's because the current page changes but it didn't get the opportunity to do a call to the API to turn the slug into a group id. We could handle that particular case differently but I figured it would be more elegant to use the `group.slug` everywhere. It's also easier to debug as a slug is more human readable than an id.

It also simplifies the custom categories for all wwcode groups and others.

I also took the opportunity to make our code works with the Redux Google Chrome Extension. It's pretty cool and useful to debug step by step.