### PR TITLE
default collective as homepage for custom domain

### DIFF
--- a/frontend/src/components/Invoice.js
+++ b/frontend/src/components/Invoice.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import Currency from './Currency';
 import Table from 'rc-table';
 import {getGroupCustomStyles} from '../lib/utils';
+import config from 'config';
 
 export default class Invoice extends Component {
 
@@ -41,9 +42,12 @@ export default class Invoice extends Component {
 
     const hostBillingAddress = { __html : (transaction.host.billingAddress || '').replace(/\n/g,'<br />') };
     const userBillingAddress = { __html : (transaction.user.billingAddress || '').replace(/\n/g,'<br />') };
-    console.log("transaction", transaction);
-    console.log("hostBillingAddress", hostBillingAddress);
     const styles = getGroupCustomStyles(transaction.group);
+
+    // We need to load images in absolute path for PhantomJS
+    if (styles.hero.cover.backgroundImage && styles.hero.cover.backgroundImage.match(/url\(\//)) {
+      styles.hero.cover.backgroundImage = styles.hero.cover.backgroundImage.replace('url(/', `url(${config.host.website}/`);
+    }
 
     return (
       <div className='Invoice'>

--- a/frontend/src/containers/PublicGroup.js
+++ b/frontend/src/containers/PublicGroup.js
@@ -357,7 +357,7 @@ function mapStateToProps({
   app
 }) {
   const { query } = router.location;
-  const slug = router.params.slug.toLowerCase();
+  const slug = Object.keys(groups)[0];
 
   const newUserId = query.userid;
   const paypalUser = {

--- a/frontend/src/containers/PublicPage.js
+++ b/frontend/src/containers/PublicPage.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import values from 'lodash/values';
 
+import HomePage from './HomePage';
 import ProfilePage from './ProfilePage';
 import PublicGroup from './PublicGroup';
 import Collective from './Collective'
@@ -17,8 +18,10 @@ export class PublicPage extends Component {
       return <ProfilePage profile={ profile } />
     } else if (this.props.showOldCollectivePage) {
       return <PublicGroup />
-    } else {
+    } else if (this.props.group.slug ) {
       return <Collective />
+    } else {
+      return <HomePage />
     }
   }
 }

--- a/frontend/src/containers/Transactions.js
+++ b/frontend/src/containers/Transactions.js
@@ -144,7 +144,7 @@ function mapStateToProps({
   users,
   router
 }) {
-  const slug = router.params.slug.toLowerCase();
+  const slug = Object.keys(groups)[0];
   const type = router.params.type || 'expenses'; // `expenses` or `donations` -> should be `revenue` to be more accurate
 
   const group = groups[slug] || {slug}; // to refactor to allow only one group

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -10,7 +10,6 @@ import DonatePage from './containers/DonatePage';
 import EditTwitter from './components/EditTwitter';
 import Faq from './containers/Faq';
 import GroupTierList from './containers/GroupTierList';
-import HomePage from './containers/HomePage';
 import Ledger from './containers/Ledger';
 import Login from './containers/Login';
 import NewGroup from './containers/NewGroup';
@@ -24,7 +23,7 @@ import { requireAuthentication } from './components/AuthenticatedComponent';
 
 export default (
   <Route>
-    <Route path="/" component={HomePage} />
+    <Route path="/" component={PublicPage} />
     <Route path="/services/email/:action(unsubscribe|approve)" component={Response} />
     <Route path="/about" component={About} />
     <Route path="/faq" component={Faq} />

--- a/server/src/controllers/homepage.js
+++ b/server/src/controllers/homepage.js
@@ -1,6 +1,16 @@
 import api from '../lib/api';
+import { fetchProfileBySlug, addMeta } from '../middlewares';
 
 export default (req, res, next) => {
+
+  /**
+   * If the host is brusselstogether.org, the homepage should be the supercollective /brusselstogether
+   */
+  if (req.host.match(/brusselstogether\.org/i)) {
+    req.params.slug = 'brusselstogether';
+    return fetchProfileBySlug(req, res, () => addMeta(req, res, next));
+  }
+
   api
     .get(`/homepage`, { cache: 60 * 60 }) // cache for one hour
     .then(homepage => {

--- a/server/src/views/helpers/busted.js
+++ b/server/src/views/helpers/busted.js
@@ -8,13 +8,12 @@ const cache = {};
 
 export default (file) => {
   if (!config.cacheBust) {
-    return `${config.host.website}/static${file}`;
+    return `/static${file}`;
   }
 
   if (!cache[file]) {
     // make it a relative path so it hits the static middleware
-    console.log("BUSTING: ", dir + file);
-    cache[file] = bust(dir + file, {remove: true}).replace(dir, `${config.host.website}/static`);
+    cache[file] = bust(dir + file, {remove: true}).replace(dir, `/static`);
   }
 
   return cache[file];

--- a/server/src/views/pages/invoice.hbs
+++ b/server/src/views/pages/invoice.hbs
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="{{{ cachebust '/css/invoice.css' }}}">
+    <link rel="stylesheet" type="text/css" href="{{config.host.website}}{{{ cachebust '/css/invoice.css' }}}">
     <title>Open Collective Invoice</title>
   </head>
   <body>


### PR DESCRIPTION
I found a more elegant solution to support a custom domain such as BrusselsTogether.org
I just force a default collective to show instead of the homepage and we make sure we don't induce the slug from the URL.

I also had to make sure we would load the CSS from a relative path, except for the invoice PDF.