### PR TITLE
new route to approve/reject expense automatically

### DIFF
--- a/frontend/src/containers/Ledger.js
+++ b/frontend/src/containers/Ledger.js
@@ -39,7 +39,7 @@ import { getAppRenderedSelector } from '../selectors/app';
 import { 
   getUsersSelector } from '../selectors/users';
 import { getAuthenticatedUserSelector } from '../selectors/session';
-import { getPathnameSelector } from '../selectors/router';
+import { getPathnameSelector, getParamsSelector } from '../selectors/router';
 import {
   getApproveInProgressSelector,
   getRejectInProgressSelector,
@@ -157,8 +157,18 @@ export class Ledger extends Component {
       fetchUsers,
       fetchPendingExpenses,
       fetchTransactions,
-      loadData
+      loadData,
+      params
     } = this.props;
+
+    switch (params.action) {
+      case 'approve':
+        approveExp(params.expenseid);
+        break;
+      case 'reject':
+        rejectExp(params.expenseid);
+        break;
+    }
 
     if (loadData) { // useful when not server-side rendered
       fetchProfile(collective.slug);
@@ -241,6 +251,7 @@ const mapStateToProps = createStructuredSelector({
   i18n: getI18nSelector,
   loadData: getAppRenderedSelector,
   pathname: getPathnameSelector,
+  params: getParamsSelector
 });
 
 export default connect(mapStateToProps, {

--- a/frontend/src/containers/Ledger.js
+++ b/frontend/src/containers/Ledger.js
@@ -50,6 +50,8 @@ export class Ledger extends Component {
 
   constructor(props) {
     super(props);
+    this.approveExp = approveExp.bind(this);
+    this.rejectExp = rejectExp.bind(this);
     let showTransactions = true;
     let showUnpaidExpenses = true;
     const showSubmitExpense = Boolean(props.pathname.match(/new$/));
@@ -163,10 +165,10 @@ export class Ledger extends Component {
 
     switch (params.action) {
       case 'approve':
-        approveExp(params.expenseid);
+        this.approveExp(params.expenseid);
         break;
       case 'reject':
-        rejectExp(params.expenseid);
+        this.rejectExp(params.expenseid);
         break;
     }
 

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -41,13 +41,14 @@ export default (
     <Route path="/:slug/connect/:provider" component={ConnectProvider} />
     <Route path="/:slug/edit-twitter" component={EditTwitter} />
     <Route path="/:slug" component={PublicPage} />
+    {/* TODO: #cleanup we shouldn't have expenses after /transactions/ */}
     <Route path="/:slug/transactions/expenses/new" component={Ledger} />
     <Route path="/:slug/transactions/expenses" component={Ledger} />
+    <Route path="/:slug/expenses/:expenseid/:action(approve|reject)" component={Ledger} />
     <Route path="/:slug/transactions" component={Ledger} />
     {/* TODO: #cleanup remove next two routes when new collective page is launched */}
     <Route path="/:slug/expenses/new" component={Transactions} />
     <Route path="/:slug/:type(donations|expenses)" component={Transactions} />
-
     <Route path="/:slug/donate/:amount" component={DonatePage} />
     <Route path="/:slug/donate/:amount/:interval" component={DonatePage} />
     <Route path="/:slug/:tier" component={GroupTierList} />

--- a/frontend/src/selectors/router.js
+++ b/frontend/src/selectors/router.js
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
  */
 const getRouterSelector = (state) => state.router;
 
-const getParamsSelector = createSelector(
+export const getParamsSelector = createSelector(
   getRouterSelector,
   (router) => router.params || {});
 

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -129,7 +129,7 @@ export default (app) => {
   // TODO: #cleanup remove next two routes when new collective page is live
   app.get('/:slug([A-Za-z0-9-_]+)/:type(expenses|donations)', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-_]+)/expenses/new', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
-  app.get('/:slug([A-Za-z0-9-_]+)/expenses/:expenseid/:action', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
+  app.get('/:slug([A-Za-z0-9-_]+)/expenses/:expenseid/:action', mw.ga, mw.fetchProfileBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-_]+)/donate/:amount', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-_]+)/donate/:amount/:interval', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-_]+)', mw.ga, mw.fetchProfileBySlug, mw.addMeta, render);

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -129,6 +129,7 @@ export default (app) => {
   // TODO: #cleanup remove next two routes when new collective page is live
   app.get('/:slug([A-Za-z0-9-_]+)/:type(expenses|donations)', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-_]+)/expenses/new', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
+  app.get('/:slug([A-Za-z0-9-_]+)/expenses/:expenseid/:action', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-_]+)/donate/:amount', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-_]+)/donate/:amount/:interval', mw.ga, mw.fetchGroupBySlug, mw.addMeta, render);
   app.get('/:slug([A-Za-z0-9-_]+)', mw.ga, mw.fetchProfileBySlug, mw.addMeta, render);


### PR DESCRIPTION
New route `/:slug/expenses/:expenseid/:action(approve|reject)` to automatically approve or reject an expense. The API will return an error if the logged in user doesn't have the right permissions.