### PR TITLE
fix login redirect bug user hit on Friday

### DIFF
--- a/frontend/src/containers/Login.js
+++ b/frontend/src/containers/Login.js
@@ -96,7 +96,7 @@ export function mapStateToProps({notification, router, form}) {
   return {
     notification,
     error: form.schema.error,
-    redirectRoute: router.location.query.next || '/',
+    redirectRoute: router.location.query.next && router.location.query.next === '/login' ? '/' : router.location.query.next,
     token: router.params.token,
   };
 }


### PR DESCRIPTION
user was confused when /login/:token?next=/login kept taking her back to login page. Now by default, if there is a token and redirect says '/login', it'll take you to homepage.