### PR TITLE
Allow to display also inactive/one-time sponsors in embedded list and JSON data

### DIFF
--- a/server/src/middlewares.js
+++ b/server/src/middlewares.js
@@ -9,9 +9,10 @@ import _ from 'lodash';
 /**
  * Fetch users by slug
  */
-const fetchActiveUsers = (options = {}) => {
+const fetchUsers = (options = {}) => {
   return (req, res, next) => {
 
+    const requireActive = (typeof options.requireActive === 'boolean') ? options.requireActive : req.query.requireActive !== 'false'; // by default, we skip inactive users
     const filters = {
       tier: req.params.tier,
       exclude: req.query.exclude,
@@ -26,7 +27,7 @@ const fetchActiveUsers = (options = {}) => {
         break;
       default:
         options.cache = 300;
-        fetchUsers = api.get(`/groups/${req.params.slug}/users?filter=active`, options)
+        fetchUsers = api.get(`/groups/${req.params.slug}/users${requireActive ? '?filter=active' : ''}`, options)
                         .then(users => _.uniqBy(users, 'id'));
         break;
     }
@@ -236,7 +237,7 @@ export default {
   fetchProfileBySlug,
   fetchTransactionByUUID,
   extractGithubUsernameFromToken,
-  fetchActiveUsers,
+  fetchUsers,
   ga,
   handleUncaughtError
 }

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -86,17 +86,17 @@ export default (app) => {
    * Routes
    */
   app.get('/:slug/:image(avatar|logo).:format(txt|png|jpg|gif|svg)', mw.maxAge(300), mw.fetchProfileBySlug, controllers.banner.logo);
-  app.get('/:slug/banner.md', mw.maxAge(300), mw.fetchGroupBySlug, mw.fetchActiveUsers(), controllers.banner.markdown);
-  app.get('/:slug/banner.js', mw.maxAge(3000), mw.fetchGroupBySlug, mw.fetchActiveUsers(), controllers.banner.js);
+  app.get('/:slug/banner.md', mw.maxAge(300), mw.fetchGroupBySlug, mw.fetchUsers(), controllers.banner.markdown);
+  app.get('/:slug/banner.js', mw.maxAge(3000), mw.fetchGroupBySlug, mw.fetchUsers(), controllers.banner.js);
   app.get('/:slug.json', mw.maxAge(900), mw.fetchProfileBySlug, renderJSON('collective'));
-  app.get('/:slug/:tier.md', mw.maxAge(300), mw.fetchGroupBySlug, mw.fetchActiveUsers(), controllers.banner.markdown);
-  app.get('/:slug/:tier.json', mw.maxAge(900), mw.fetchActiveUsers(), renderJSON('users'));
+  app.get('/:slug/:tier.md', mw.maxAge(300), mw.fetchGroupBySlug, mw.fetchUsers(), controllers.banner.markdown);
+  app.get('/:slug/:tier.json', mw.maxAge(900), mw.fetchUsers(), renderJSON('users'));
   app.get('/:slug/transactions/:transactionuuid.json', mw.maxAge(900), mw.fetchTransactionByUUID, renderJSON('transaction'));
-  app.get('/:slug/:tier.:format(svg|png)', mw.maxAge(300), mw.fetchActiveUsers(), controllers.banner.banner);
-  app.get('/:slug/:tier/badge.svg', mw.maxAge(300), mw.fetchActiveUsers({requireAvatar: false}), controllers.banner.badge);
-  app.get('/:slug/badge/:tier.svg', mw.maxAge(300), mw.fetchActiveUsers({requireAvatar: false}), controllers.banner.badge);
-  app.get('/:slug/:tier/:position/avatar(.:format(png|jpg|svg))?', mw.maxAge(300), mw.ga, mw.fetchActiveUsers({cache: 300}), controllers.banner.avatar);
-  app.get('/:slug/:tier/:position/website', mw.ga, mw.fetchActiveUsers(), controllers.banner.redirect);
+  app.get('/:slug/:tier.:format(svg|png)', mw.maxAge(300), mw.fetchUsers(), controllers.banner.banner);
+  app.get('/:slug/:tier/badge.svg', mw.maxAge(300), mw.fetchUsers({requireAvatar: false}), controllers.banner.badge);
+  app.get('/:slug/badge/:tier.svg', mw.maxAge(300), mw.fetchUsers({requireAvatar: false}), controllers.banner.badge);
+  app.get('/:slug/:tier/:position/avatar(.:format(png|jpg|svg))?', mw.maxAge(300), mw.ga, mw.fetchUsers({cache: 300}), controllers.banner.avatar);
+  app.get('/:slug/:tier/:position/website', mw.ga, mw.fetchUsers(), controllers.banner.redirect);
   app.get('/:slug([A-Za-z0-9-]+)/widget', mw.maxAge(300), mw.fetchProfileBySlug, controllers.widgets.profile);
   app.get('/:slug([A-Za-z0-9-]+)/widget.js', mw.maxAge(3000), controllers.widgets.js);
 


### PR DESCRIPTION
Currently the lists doesn't show one-time sponsors, because they are not "active".

This PR fixes this and shows every sponsor regardless of activity.

This aligns the embedded sponsor list with the list on the opencollective website.