### PR TITLE
Awesome site, small oversight

### DIFF
--- a/frontend/src/css/containers/About.css
+++ b/frontend/src/css/containers/About.css
@@ -118,10 +118,8 @@
   }
 }
 
-@media (max-width: 600px) {
-  .About .About-container {
-    padding: 30px;
-  }
+.About .About-container {
+  padding: 30px;
 }
 
 


### PR DESCRIPTION
Underneath "Our Founding Team" you're losing padding on that paragraph `<p data-reactid=".0.2.2">...</p>` above 900px

What makes the most sense for a quick n' dirty fix here is to simply remove that 600px media query, so you've always got 30px of padding on the ".About-container"

Cheers!