### PR TITLE
css fix for /donate page

### DIFF
--- a/frontend/src/css/containers/DonatePage.css
+++ b/frontend/src/css/containers/DonatePage.css
@@ -45,6 +45,9 @@
     }
   }
   .CollectiveDonationFlowWrapper {
+    align-items: baseline;
+    padding: 1rem;
+    box-sizing: border-box;
     & > div {
       max-width: 600px;
     }


### PR DESCRIPTION
this fixes the issue where the logo would be cut off at the top
e.g. https://opencollective.com/sustainoss/donate/500