### PR TITLE
add the tags of the host to the new collective

### DIFF
--- a/frontend/src/containers/NewGroup.js
+++ b/frontend/src/containers/NewGroup.js
@@ -17,6 +17,8 @@ import validateSchema from '../actions/form/validate_schema';
 
 import newGroupSchema from '../joi_schemas/newGroup';
 
+import { uniq } from 'lodash';
+
 export class NewGroup extends Component {
 
   constructor(props) {
@@ -250,6 +252,7 @@ export class NewGroup extends Component {
   create() {
     const { newGroupForm, validateSchema, createGroup, utmSource, notify, hostCollective } = this.props;
     const attr = newGroupForm.attributes;
+    const tags = attr.tags && attr.tags.split(',').map(x => x.trim());
 
     const group = {
       tos: attr.tos,
@@ -262,7 +265,7 @@ export class NewGroup extends Component {
       data: {
         utmSource
       },
-      tags: attr.tags && attr.tags.split(',').map(x => x.trim()),
+      tags: uniq([...tags, ...hostCollective.tags]),
       users: attr.users
     };
 

--- a/frontend/src/containers/NewGroup.js
+++ b/frontend/src/containers/NewGroup.js
@@ -265,6 +265,7 @@ export class NewGroup extends Component {
       longDescription: attr.contribute ? `${attr.description}\n\n# Contribute\n\n${attr.contribute}` : attr.description,
       website: attr.website,
       HostId: hostCollective && hostCollective.settings.HostId,
+      hostFeePercent: hostCollective && hostCollective.settings.hostFeePercent || 5,
       data: {
         utmSource
       },

--- a/frontend/src/containers/NewGroup.js
+++ b/frontend/src/containers/NewGroup.js
@@ -63,6 +63,12 @@ export class NewGroup extends Component {
     } = newGroupForm.attributes;
 
     const groupTypes = new Map();
+    groupTypes.set('association', {
+      label: 'Association'
+    });
+    groupTypes.set('coop', {
+      label: 'Cooperative'
+    });
     groupTypes.set('meetup',{
       label: 'Meetup Group',
       placeholders: {
@@ -73,8 +79,11 @@ export class NewGroup extends Component {
         contribute: 'We need more people to join the community and attend our events. We are also looking for volunteers to help us organize our meetups.'
       }
     });
+    groupTypes.set('movement', {
+      label: 'Movement'
+    });
     groupTypes.set('opensource', {
-      label: 'OpenSource Project',
+      label: 'Open Source Project',
       placeholders: {
         name: 'MochaJS',
         slug: 'mochajs',
@@ -88,12 +97,6 @@ export class NewGroup extends Component {
     });
     groupTypes.set('studentclub', {
       label: 'Student Club'
-    });
-    groupTypes.set('movement', {
-      label: 'Movement'
-    });
-    groupTypes.set('association', {
-      label: 'Association'
     });
     groupTypes.set('default', {
       label: 'Other',


### PR DESCRIPTION
Also added host fee defined by parent host (in `group.settings.hostFeesPercent`, defaults to 5%) and added a new type "coop" as one user was suggesting on Twitter.

For a new host that wants and `/apply`, we need to create a group that has in its settings:

    {
      "HostId": Integer, // User Id of the Host User
      "hostFeesPercent": 5, // optional: percentage for the host (default: 5)
      "superCollectiveTag": "wwcode" // show all collectives that have the same tag on the page
    }