### PR TITLE
Remove border-radius from logo preview to look same for editors and visitors

### DIFF
--- a/frontend/src/css/components/ImagePicker.css
+++ b/frontend/src/css/components/ImagePicker.css
@@ -72,11 +72,6 @@
   cursor: pointer;
 }
 
-.avatar .ImagePicker-preview
-{
-  border-radius: 100%;
-}
-
 .logo .ImagePicker-preview
 {
   border-radius: 6px;


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/350

Currently visitors (left) see a normal logo, but for editors / admins / core contributors (right) it is rounded in the view.
![screenshot from 2017-05-18 15-11-27](https://cloud.githubusercontent.com/assets/925062/26203778/d91a480e-3bdc-11e7-9326-e50617abb6e3.png)

That is confusing especially for us because we recently had to change our logo from the round version to square because of a trademark reference. I even uploaded a version of our logo with appropriate margins next to the logo so it wouldn’t be caught by the rounding – unaware that users see the full logo anyway.

This edit removes the radius so it simply looks the same for both visitors/users and editors/admins.