### PR TITLE
make sure users with multiple roles show up as backers

### DIFF
--- a/server/src/middlewares.js
+++ b/server/src/middlewares.js
@@ -10,6 +10,8 @@ import _ from 'lodash';
  * Fetch users by slug
  */
 const fetchUsers = (options = {}) => {
+  options.cache = options.cache || 300; // default cache for api requests to fetch users: 5mn
+
   return (req, res, next) => {
 
     const requireActive = (typeof options.requireActive === 'boolean') ? options.requireActive : req.query.requireActive !== 'false'; // by default, we skip inactive users
@@ -27,8 +29,14 @@ const fetchUsers = (options = {}) => {
         break;
       default:
         options.cache = 300;
-        fetchUsers = api.get(`/groups/${req.params.slug}/users${requireActive ? '?filter=active' : ''}`, options)
-                        .then(users => _.uniqBy(users, 'id'));
+        fetchUsers = api.get(`/groups/${req.params.slug.toLowerCase()}/users${requireActive ? '?filter=active' : ''}`, options)
+                        .then(users => _.filter(users, (u) => {
+                          if (filters.tier) {
+                            return u.tier === filters.tier;
+                          } else {
+                            return true;
+                          }
+                        }));
         break;
     }
 

--- a/server/src/middlewares.js
+++ b/server/src/middlewares.js
@@ -32,7 +32,7 @@ const fetchUsers = (options = {}) => {
         fetchUsers = api.get(`/groups/${req.params.slug.toLowerCase()}/users${requireActive ? '?filter=active' : ''}`, options)
                         .then(users => _.filter(users, (u) => {
                           if (filters.tier) {
-                            return u.tier === filters.tier;
+                            return u.tier === filters.tier || u.tier === filters.tier.replace(/s$/, '');
                           } else {
                             return true;
                           }


### PR DESCRIPTION
If a user is both a core contributor and a backer, the `_.uniq(users, "id")` would randomly pick the user with the role core contributor or with the role backer. That's why they wouldn't always show up as backers.

Bug reported by https://opencollective.com/kaku

