### PR TITLE
add create event link to menu bar -- only for core contributors for now

### DIFF
--- a/frontend/src/components/collective/CollectiveHero.js
+++ b/frontend/src/components/collective/CollectiveHero.js
@@ -89,6 +89,11 @@ export default class CollectiveHero extends Component {
               <li className='inline-block'>
                 <a href='#contributors' className='block white -ff-sec -fw-bold'>{ i18n.getString('contributors') }</a>
               </li>
+              { canEditCollective &&
+                <li className='inline-block xs-hide'>
+                  <a href={`/${collective.slug}/events/new`} className='block white -ff-sec -fw-bold'>Create an Event</a>
+                </li>
+              }
               { collective.backersCount > 0 && canEditCollective &&
                 <li className='inline-block xs-hide'>
                   <a href='#exportMembers' className='block white -ff-sec -fw-bold' onClick={ exportMembers.bind(this, loggedinUser, collective) } >Export members.csv</a>


### PR DESCRIPTION
This is just a first step. It will only show the link to create an event to core contributors.

Next step would be to allow any member (backer/sponsor included) to create an event (see https://github.com/opencollective/opencollective-api/pull/900) -- but we should think about how to communicate this to all core contributors, we don't want to take them by surprise.