### PR TITLE
link to the new /transactions page from the collective page

### DIFF
--- a/frontend/src/components/collective/CollectiveLedger.js
+++ b/frontend/src/components/collective/CollectiveLedger.js
@@ -25,9 +25,9 @@ export default class CollectiveLedger extends Component {
             <CollectiveTransactions {...this.props} transactions={ collective.transactions }/>
             <div className='center pt2'>
               {(collective.transactions.length === 0) && (
-                <Link className='-btn -btn-medium -btn-outline -border-green -ttu -fw-bold' to={`/${collective.slug}/transactions`}>
+                <a className='-btn -btn-medium -btn-outline -border-green -ttu -fw-bold' href={`/${collective.slug}/transactions`}>
                   {i18n.getString('seeAllTransactions')} >
-                </Link>
+                </a>
               )}
             </div>
           </div>

--- a/frontend/src/components/collective/CollectiveLedger.js
+++ b/frontend/src/components/collective/CollectiveLedger.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import { Link } from 'react-router';
 
 import CollectivePendingExpenses from './CollectivePendingExpenses';
 import CollectiveTransactions from './CollectiveTransactions';

--- a/frontend/src/components/collective/CollectiveTransactions.js
+++ b/frontend/src/components/collective/CollectiveTransactions.js
@@ -30,9 +30,9 @@ export default class CollectiveTransactions extends React.Component {
         </div>
         <div className='center pt2'>
           {(transactions.length >= itemsToShow) && (
-            <Link className='-btn -btn-medium -btn-outline -border-green -ttu -fw-bold' to={`/${collective.slug}/transactions`}>
+            <a className='-btn -btn-medium -btn-outline -border-green -ttu -fw-bold' href={`/${collective.slug}/transactions`}>
               {i18n.getString('seeAllTransactions')} >
-            </Link>
+            </a>
           )}
         </div>
       </div>

--- a/frontend/src/components/collective/CollectiveTransactions.js
+++ b/frontend/src/components/collective/CollectiveTransactions.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router';
 
 import CollectiveActivityItem from './CollectiveActivityItem';
 import TransactionEmptyState from '../TransactionEmptyState';


### PR DESCRIPTION
This makes sure that we are loading the new /transactions page instead of the old one.