### PR TITLE
bill to the collective that made the transaction

### DIFF
--- a/frontend/src/components/Invoice.js
+++ b/frontend/src/components/Invoice.js
@@ -101,7 +101,7 @@ export default class Invoice extends Component {
             </div>
             <div className="userBillingAddress">
               <h2>{i18n.getString('billTo')}:</h2>
-              {transaction.fromCollective.name}<br />
+              {transaction.collective.name}<br />
               <div dangerouslySetInnerHTML={userBillingAddress} />
             </div>
           </div>


### PR DESCRIPTION
The bill to was showing the name of the collective that received the money instead of the collective that gave the money (because we use the DEBIT Transaction)